### PR TITLE
fix to work fine in new google's result page

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -91,7 +91,7 @@ After pressing the button, you can check if Splinter official website is among t
 
 ::
 
-    if browser.is_text_present('http://splinter.cobrateam.info'):
+    if browser.is_text_present('splinter.cobrateam.info/'):
         print "Yes, found it! :)"
     else:
         print "No, didn't find it :("
@@ -126,7 +126,7 @@ Finally, the source code will be:
     browser.fill('q', 'splinter - python acceptance testing for web applications')
     browser.find_by_css('.lsb').first.click()
 
-    if browser.is_text_present('http://splinter.cobrateam.info'):
+    if browser.is_text_present('splinter.cobrateam.info/'):
         print "Yes, the official website was found!"
     else:
         print "No, it wasn't found... We need to improve our SEO techniques"


### PR DESCRIPTION
Google updated the layout of results page. And this affected the splinter's tutorial page.

In the results, before the update: http://splinter.cobrateam.info
After update: splinter.cobrateam.info/

So I just changed from: browser.is_text_present('http://splinter.cobrateam.info') to browser.is_text_present('splinter.cobrateam.info/')
