### PR TITLE
Changing the way to run the chrome webdriver, and adding a new note that could help

### DIFF
--- a/docs/drivers/chrome.rst
+++ b/docs/drivers/chrome.rst
@@ -110,4 +110,5 @@ the ``Browser`` instance:
     browser = Browser('webdriver.chrome')
 
 **Note:** if you don't provide any driver to ``Browser`` function, ``webdriver.firefox`` will be used.
+
 **Note:** if you have trouble with ``$HOME/.bash_profile``, may you could to try ``$HOME/.bashrc``.


### PR DESCRIPTION
I just try to execute the code `Browser('firefox.chrome')` and i realized that was wrong, so i change to the right way to execute the chrome webdriver.

And when i was configuring, in this step: 

```
$ mkdir -p $HOME/bin
$ mv chromedriver $HOME/bin
$ echo "export PATH=$PATH:$HOME/bin" >> $HOME/.bash_profile
```

I just think that will be helpful add a note, cause, for example, in my Ubuntu don't exists `.bash_profile`, exists the `.bashrc`

Just in case that happen the same error with someone.
