### PR TITLE
Added link to set up splinter development environment to Install guide

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -48,5 +48,6 @@ Otherwise, if you want Splinter's latest-and-greatest features and aren't afraid
 
 **Notes:**
 
+    * - make sure you have already :doc:`set up your development environment </contribute/setting-up-your-development-environment>`.
     * - in this second case, make sure `Git <http://git-scm.com/>`_  is installed.
     * - in order to use Chrome webdriver, you need to :doc:`setup Google Chrome properly </drivers/chrome>`.


### PR DESCRIPTION
I was having troubles to install splinter (specifically lxml) because it was missing some dependencies.

I thought it will be useful to put a link in Install guide page to Set up the development enviroment page.
