### PR TITLE
Added support for Selenium-RC webdriver

### DIFF
--- a/splinter/browser.py
+++ b/splinter/browser.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from splinter.driver.webdriver.firefox import WebDriver as FirefoxWebDriver
+from splinter.driver.webdriver.remote import WebDriver as RemoteWebDriver
 from splinter.driver.webdriver.chrome import WebDriver as ChromeWebDriver
 from splinter.exceptions import DriverNotFoundError
 from splinter.utils import deprecate_driver_class
@@ -7,6 +8,7 @@ from splinter.utils import deprecate_driver_class
 
 _DRIVERS = {
     'firefox': FirefoxWebDriver,
+    'remote': RemoteWebDriver,
     'chrome': ChromeWebDriver,
     'webdriver.chrome': deprecate_driver_class(ChromeWebDriver, message="'webdriver.chrome' is deprecated, use just 'chrome'"),
     'webdriver.firefox': deprecate_driver_class(FirefoxWebDriver, message="'webdriver.firefox' is deprecated, use just 'firefox'"),

--- a/splinter/driver/webdriver/remote.py
+++ b/splinter/driver/webdriver/remote.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import subprocess
+
+from selenium.webdriver import Remote
+from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
+from splinter.driver.webdriver import BaseWebDriver, WebDriverElement as BaseWebDriverElement
+from splinter.driver.webdriver.cookie_manager import CookieManager
+
+
+class WebDriver(BaseWebDriver):
+
+    def __init__(self, server, port=4443, profile=None, extensions=None):
+        self.old_popen = subprocess.Popen
+        firefox_profile = FirefoxProfile(profile)
+        firefox_profile.set_preference('extensions.logging.enabled', False)
+        firefox_profile.set_preference('network.dns.disableIPv6', False)
+
+        if extensions:
+            for extension in extensions:
+                firefox_profile.add_extension(extension)
+
+        self._patch_subprocess()
+        dest = 'http://%s:%s/wd/hub'%(server,port)
+        self.driver = Remote(dest, {}, firefox_profile)
+        self._unpatch_subprocess()
+
+        self.element_class = WebDriverElement
+
+        self._cookie_manager = CookieManager(self.driver)
+
+        super(WebDriver, self).__init__()
+
+
+class WebDriverElement(BaseWebDriverElement):
+
+    def mouse_over(self):
+        """
+        Remote Firefox doesn't support mouseover.
+        """
+        raise NotImplementedError("Remote Firefox doesn't support mouse over")
+
+    def mouse_out(self):
+        """
+        Remote Firefox doesn't support mouseout.
+        """
+        raise NotImplementedError("Remote Firefox doesn't support mouseout")
+
+    def double_click(self):
+        """
+        Remote Firefox doesn't support doubleclick.
+        """
+        raise NotImplementedError("Remote Firefox doesn't support doubleclick")
+
+    def right_click(self):
+        """
+        Remote Firefox doesn't support right click'
+        """
+        raise NotImplementedError("Remote Firefox doesn't support right click")
+
+    def drag_and_drop(self, droppable):
+        """
+        Remote Firefox doesn't support drag and drop
+        """
+        raise NotImplementedError("Remote Firefox doesn't support drag an drop")
+
+    mouseover = mouse_over
+    mouseout = mouse_out


### PR DESCRIPTION
Very basic, copied the Firefox webdriver and changed a few lines. Only support Firefox on remote server, currently... I think... Haven't tested support for using a local firefox profile (or local extensions) with RC server, but the code is still there for it.
Was uncertain if this driver should use the custom cookie manager, as Chrome and Firefox both do -- Left the code for this in place.

Very hackish and unfinished, but works well enough for my needs. Thanks!
