### PR TITLE
Update fill_form to support textarea

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -239,7 +239,7 @@ class BaseWebDriver(DriverAPI):
         for name, value in field_values.items():
             elements = self.find_by_name(name)
             element = elements.first
-            if element['type'] == 'text':
+            if element['type'] == 'text' or element.tag_name == 'textarea':
                 element.value = value
             elif element['type'] == 'checkbox':
                 if value:
@@ -320,6 +320,10 @@ class WebDriverElement(ElementAPI):
     @property
     def text(self):
         return self._element.text
+
+    @property
+    def tag_name(self):
+        return self._element.tag_name
 
     def fill(self, value):
         self.value = value

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -152,7 +152,7 @@ class ZopeTestBrowser(DriverAPI):
         for name, value in field_values.items():
             element = self.find_by_name(name)
             control = element.first._control
-            if control.type == 'text':
+            if control.type in ['text', 'textarea']:
                 control.value = value
             elif control.type == 'checkbox':
                 if value:

--- a/tests/fake_webapp.py
+++ b/tests/fake_webapp.py
@@ -94,6 +94,8 @@ EXAMPLE_HTML = """\
             <option value="mt">Mato Grosso</option>
             <option value="rj">Rio de Janeiro</option>
         </select>
+        <label for="description">Description</label>
+        <textarea rows="3" cols="50" name="description"></textarea>
     </form>
     <form action="/upload" method="POST" enctype="multipart/form-data">
         <input type="file" name="file">

--- a/tests/form_elements.py
+++ b/tests/form_elements.py
@@ -86,6 +86,7 @@ class FormElementsTest(object):
         self.assertTrue(self.browser.find_by_name("checked-checkbox").first.checked)
         self.browser.fill_form({
             'query': 'another new query',
+            'description': 'Just another description value in the textarea',
             'gender': 'M',
             'uf': 'rj',
             'some-check': True,
@@ -93,6 +94,8 @@ class FormElementsTest(object):
         })
         query_value = self.browser.find_by_name('query').first.value
         self.assertEquals('another new query', query_value)
+        desc_value = self.browser.find_by_name('description').first.value
+        self.assertEquals('Just another description value in the textarea', desc_value)
         self.assertTrue(self.browser.find_by_id("gender-m").first.checked)
         self.assertTrue(self.browser.find_option_by_value("rj").first.selected)
         self.assertTrue(self.browser.find_by_name("some-check").first.checked)


### PR DESCRIPTION
I've been using splinter the last couple of days for testing a web app
(love it!)   Tonight I noticed that fill_form() didn't seem to be setting the value for the textarea on the page under test.  I was able to follow up my fill_form call with a fill() call to get a value in the textarea, but I think having textarea support in fill_form will help save new users (like me) some time.  
This pull request adds support for setting the value of a textarea as part of the fill_form processing.  
