### PR TITLE
Solving problem due to changing on Selenium module name

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -6,7 +6,10 @@ import time
 from contextlib import contextmanager
 
 from lxml.cssselect import CSSSelector
-from selenium.common.exceptions import NoSuchElementException
+try:
+    from selenium.common.exceptions import NoSuchElementException
+except ImportError:
+    from selenium.webdriver.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.action_chains import ActionChains
 
 from splinter.driver import DriverAPI, ElementAPI


### PR DESCRIPTION
Apparently, the new Selenium version (2.20.0) used in Splinter 0.4.4  changed the selenium.common.exceptions module to selenium.webdriver.common.exceptions, which broke a lot of tests. So I made a little change: it tries to get the old one and, in case of failing, tries to import the new one.
