### PR TITLE
Use .text_content for ZopeTestBrowserElement value

### DIFF
--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -249,7 +249,7 @@ class ZopeTestBrowserElement(ElementAPI):
 
     @property
     def value(self):
-        return self._element.text
+        return self._element.text_content()
 
     @property
     def text(self):


### PR DESCRIPTION
The text(without markup) of an lxml.html Element is not given by the
method .text(), but by the method .text_content()
