### PR TITLE
zope driver attach_file method does not work

### DIFF
--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -193,9 +193,10 @@ class ZopeTestBrowser(DriverAPI):
         control.value = []
 
     def attach_file(self, name, file_path):
+        filename = file_path.split('/')[-1]
         control = self._browser.getControl(name=name)
         content_type, _ = mimetypes.guess_type(file_path)
-        control.add_file(open(file_path), content_type, None)
+        control.add_file(open(file_path), content_type, filename)
 
     def _find_links_by_xpath(self, xpath):
         html = lxml.html.fromstring(self.html)


### PR DESCRIPTION
As posted @ https://github.com/cobrateam/splinter/issues/175

"I was writing tests for an application that required attaching files and I happened to notice that no file was uploaded using this implementation. After looking through Splinter source and Zope documentations. Basically, the filename argument in the attach_file method source is set to None instead of specifying a filename."
