### PR TITLE
Fix typo in test values

### DIFF
--- a/tests/element.py
+++ b/tests/element.py
@@ -21,7 +21,7 @@ class ElementTest(object):
 
     def test_element_outer_html(self):
         self.assertEqual(self.browser.find_by_id('html-property').first.outer_html,
-                u'<div id="html-property" class="outer html &gt; classes">inner <div class="inner-html">inner text</div> html test</div>')
+                u'<div id="html-property" class="outer html classes">inner <div class="inner-html">inner text</div> html test</div>')
 
     def test_element_html(self):
         self.assertEqual(self.browser.find_by_id('html-property').first.html,

--- a/tests/static/index.html
+++ b/tests/static/index.html
@@ -123,7 +123,7 @@
     <div class="droppable">droppable</div>
     <div class="dragged">no</div>
     <div class="has-class-first has-class-middle has-class-end"></div>
-    <div id="html-property" class="outer html > classes">inner <div class="inner-html">inner text</div> html test</div>
+    <div id="html-property" class="outer html classes">inner <div class="inner-html">inner text</div> html test</div>
     <a id="open-popup" href="javascript:poptastic('/popup')">Open pop-up window</a>
     <script>
       function poptastic(url) {


### PR DESCRIPTION
Fixes a test failure I got:

``` python
FAILURES

Test method: test_element_outer_html (test_webdriver_firefox.FirefoxBrowserTest)
Traceback (most recent call last):
  File "/home/medwards/forks/splinter/tests/element.py", line 24, in test_element_outer_html
    u'<div id="html-property" class="outer html &gt; classes">inner <div class="inner-html">inner text</div> html test</div>')
AssertionError: u'<div id="html-property" class="outer html > classes">inner <div class="inner-h [truncated]... != u'<div id="html-property" class="outer html &gt; classes">inner <div class="inne [truncated]...
- <div id="html-property" class="outer html > classes">inner <div class="inner-html">inner text</div> html test</div>
?                                           ^
+ <div id="html-property" class="outer html &gt; classes">inner <div class="inner-html">inner text</div> html test</div>
?                                           ^^^^
```
