### PR TITLE
Add wait_time arg to drive constructors

### DIFF
--- a/splinter/driver/webdriver/chrome.py
+++ b/splinter/driver/webdriver/chrome.py
@@ -14,7 +14,7 @@ class WebDriver(BaseWebDriver):
 
     driver_name = "Chrome"
 
-    def __init__(self, user_agent=None):
+    def __init__(self, user_agent=None, wait_time=2):
         options = Options()
 
         if user_agent is not None:
@@ -26,4 +26,4 @@ class WebDriver(BaseWebDriver):
 
         self._cookie_manager = ChromeCookieManager(self.driver)
 
-        super(WebDriver, self).__init__()
+        super(WebDriver, self).__init__(wait_time)

--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -14,7 +14,7 @@ class WebDriver(BaseWebDriver):
 
     driver_name = "Firefox"
 
-    def __init__(self, profile=None, extensions=None, user_agent=None, profile_preferences=None):
+    def __init__(self, profile=None, extensions=None, user_agent=None, profile_preferences=None, wait_time=2):
         firefox_profile = FirefoxProfile(profile)
         firefox_profile.set_preference('extensions.logging.enabled', False)
         firefox_profile.set_preference('network.dns.disableIPv6', False)
@@ -36,7 +36,7 @@ class WebDriver(BaseWebDriver):
 
         self._cookie_manager = CookieManager(self.driver)
 
-        super(WebDriver, self).__init__()
+        super(WebDriver, self).__init__(wait_time)
 
 
 class WebDriverElement(BaseWebDriverElement):

--- a/splinter/driver/webdriver/remote.py
+++ b/splinter/driver/webdriver/remote.py
@@ -18,7 +18,7 @@ class WebDriver(BaseWebDriver):
     # TODO: This constant belongs in selenium.webdriver.Remote
     DEFAULT_URL = 'http://127.0.0.1:4444/wd/hub'
 
-    def __init__(self, url=DEFAULT_URL, browser='firefox', **ability_args):
+    def __init__(self, url=DEFAULT_URL, browser='firefox', wait_time=2, **ability_args):
         abilities = getattr(DesiredCapabilities, browser.upper(), {})
         for arg in ability_args:
             ability_args[arg] = ability_args[arg]
@@ -28,7 +28,7 @@ class WebDriver(BaseWebDriver):
 
         self._cookie_manager = CookieManagerAPI()
 
-        super(WebDriver, self).__init__()
+        super(WebDriver, self).__init__(wait_time)
 
 
 class WebDriverElement(BaseWebDriverElement):


### PR DESCRIPTION
Add support for specifying wait_time in constructors of BaseWebDriver subclasses.

This addresses issue #178.
