### PR TITLE
Fix remote WebDriver to properly pass ability_args to Selenium

### DIFF
--- a/splinter/driver/webdriver/remote.py
+++ b/splinter/driver/webdriver/remote.py
@@ -20,8 +20,7 @@ class WebDriver(BaseWebDriver):
 
     def __init__(self, url=DEFAULT_URL, browser='firefox', wait_time=2, **ability_args):
         abilities = getattr(DesiredCapabilities, browser.upper(), {})
-        for arg in ability_args:
-            ability_args[arg] = ability_args[arg]
+        abilities.update(ability_args)
         self.driver = Remote(url, abilities)
 
         self.element_class = WebDriverElement


### PR DESCRIPTION
The remote WebDriver class previously didn't actually do anything with **ability_args. These are now passed through to the Selenium driver instance.
