### PR TITLE
Fix zope.testbrowser xpath lookups for links

### DIFF
--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -118,7 +118,7 @@ class ZopeTestBrowser(DriverAPI):
 
         for xpath_element in html.xpath(xpath):
             if self._element_is_link(xpath_element):
-                return self.find_link_by_text(xpath_element.text)
+                return self._find_links_by_xpath(xpath)
             elif self._element_is_control(xpath_element):
                 return self.find_by_name(xpath_element.name)
             else:

--- a/tests/static/index.html
+++ b/tests/static/index.html
@@ -106,6 +106,8 @@
     <div id="text_with_html">another <b>b</b>it of text</div>
     <a href="http://localhost:5000/foo">FOO</a>
     <a href="http://localhost:5000/foo">A wordier (and last) link to FOO</a>
+    <a href="http://localhost:5000/bar">BAR: <span>first bar</span></a>
+    <a href="http://localhost:5000/bar">BAR: <span>second bar</span></a>
     <a class="add-async-element" href="#">add async element</a>
     <a class="remove-async-element" href="#">remove async element</a>
     <a class="add-element-mouseover" href="#">addelement (mouseover)</a>

--- a/tests/test_zopetestbrowser.py
+++ b/tests/test_zopetestbrowser.py
@@ -101,3 +101,10 @@ class ZopeTestBrowserDriverTest(BaseBrowserTests, unittest.TestCase):
         "zope.testbrowser should not be able to mouse out of an element"
         with self.assertRaises(NotImplementedError):
             self.browser.find_by_css('#visible').first.mouse_out()
+
+    def test_links_with_nested_tags_xpath(self):
+        links = self.browser.find_by_xpath('//a/span[text()="first bar"]/..')
+        self.assertEqual(
+            len(links), 1,
+            'Found not exactly one link with a span with text "BAR ONE". %s' % (
+                map(lambda item: item.outer_html, links)))


### PR DESCRIPTION
When the result of `find_by_xpath` are links we should not re-search it only by the link text but by using the original xpath expression, otherwise the result might be wrong.
The result could also contain links with the _same text content_ but which were not selected by the original xpath expression.

**Illustration of the bug:**

Given the HTML:

``` html
<div id="one"><a href="#">Foo</a></div>
<div id="two"><a href="#">Foo</a></div>
```

when doing the query:

``` python
self.browser.find_by_xpath('//div[@id="one"]/a')
```

the result did contain **both** links, because the have the same text contents - but we only did select the first one.

This is caused by the fact that `find_by_xpath` internally called `find_link_by_text` so that the result got properly wrapped into a `ZopeTestBrowserLinkElement`.

This pull request fixes this bug by using `_find_links_by_xpath` with the original xpath expression instead of using `find_link_by_text` with a link-text-only expression.

This bug and its fix only affect the `zope.testbrowser` driver, other drivers such as `firefox` are working correctly in this situation already.
