### PR TITLE
Added support for passing basic HTTP authentication in the url.

### DIFF
--- a/docs/browser.rst
+++ b/docs/browser.rst
@@ -56,6 +56,13 @@ You can use the ``visit`` method to navigate to other pages:
 
 The ``visit`` method takes only a single parameter - the ``url`` to be visited.
 
+You can visit a site protected with basic HTTP authentication by providing the
+username and password in the url.
+
+::
+
+    browser.visit('http://username:password@cobrateam.info/protected')
+
 =============
 Reload a page
 =============

--- a/splinter/request_handler/request_handler.py
+++ b/splinter/request_handler/request_handler.py
@@ -5,6 +5,7 @@
 # license that can be found in the LICENSE file.
 
 import httplib
+import base64
 from urlparse import urlparse
 from status_code import StatusCode
 
@@ -39,10 +40,17 @@ class RequestHandler(object):
         self.conn = httplib.HTTPConnection(self.host, self.port)
         self.conn.putrequest('GET', self.path)
         self.conn.putheader('User-agent', 'python/splinter')
+        if self.auth:
+            self.conn.putheader("Authorization", "Basic %s" % self.auth)
         self.conn.endheaders()
 
     def _parse_url(self):
         parsed_url = urlparse(self.request_url)
+        if parsed_url.username and parsed_url.password:
+            login = '%s:%s' % (parsed_url.username, parsed_url.password)
+            self.auth = base64.standard_b64encode(login)
+        else:
+            self.auth = None
         self.host = parsed_url.hostname
         self.port = parsed_url.port
         self.path = parsed_url.path

--- a/tests/fake_webapp.py
+++ b/tests/fake_webapp.py
@@ -4,8 +4,9 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from flask import Flask, request, abort
+from flask import Flask, request, abort, Response
 from os import path
+from functools import wraps
 
 
 this_folder = path.abspath(path.dirname(__file__))
@@ -21,6 +22,30 @@ EXAMPLE_ALERT_HTML = read_static('alert.html')
 EXAMPLE_TYPE_HTML = read_static('type.html')
 EXAMPLE_POPUP_HTML = read_static('popup.html')
 EXAMPLE_NO_BODY_HTML = read_static('no-body.html')
+
+# Functions for http basic auth. 
+# Taken verbatim from http://flask.pocoo.org/snippets/8/
+def check_auth(username, password):
+    """This function is called to check if a username /
+    password combination is valid.
+    """
+    return username == 'admin' and password == 'secret'
+
+def authenticate():
+    """Sends a 401 response that enables basic auth"""
+    return Response(
+    'Could not verify your access level for that URL.\n'
+    'You have to login with proper credentials', 401,
+    {'WWW-Authenticate': 'Basic realm="Login Required"'})
+
+def requires_auth(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth = request.authorization
+        if not auth or not check_auth(auth.username, auth.password):
+            return authenticate()
+        return f(*args, **kwargs)
+    return decorated
 
 app = Flask(__name__)
 
@@ -87,6 +112,11 @@ def query_string():
 @app.route('/popup')
 def popup():
     return EXAMPLE_POPUP_HTML
+
+@app.route('/authenticate')
+@requires_auth
+def auth_required():
+    return "Success!"
 
 
 def start_flask_app(host, port):

--- a/tests/test_request_handler.py
+++ b/tests/test_request_handler.py
@@ -82,3 +82,9 @@ class RequestHandlerTestCase(unittest.TestCase):
         url = EXAMPLE_APP + 'useragent'
         request.connect(url)
         self.assertEqual('python/splinter', request.response.read())
+
+    def test_should_be_able_to_connect_with_basic_auth(self):
+        request = RequestHandler()
+        url = 'http://admin:secret@localhost:5000/authenticate'
+        request.connect(url)
+        self.assertEqual('Success!', request.response.read())


### PR DESCRIPTION
I know that in the past the Python Selenium bindings didn't support passing auth credentials in the URL, but I just updated my selenuim library and drivers and it works now. This doesn't work with splinter because splinter establishes the connection first in `request_handler.py`.

For example, this now works with the latest Selenium bindings.

``` python
from selenium import webdriver
driver = webdriver.Firefox() # or webdriver.Chrome()
driver.get('http://user:password@example.com')
```

The eqivalent with Splinter doesn't work.

``` python
from splinter import Browser
browser = Browser()
browser.visit('http://user:password@example.com')
```

This will raise a 401 `HttpResponseError`

I have added a simple change to `request_handler.py` to support passing the credentials in this way.
