### PR TITLE
Added "all" method to CookieManager

### DIFF
--- a/splinter/cookie_manager.py
+++ b/splinter/cookie_manager.py
@@ -52,6 +52,12 @@ class CookieManagerAPI(object):
         """
         raise NotImplementedError
 
+    def all(self):
+        """
+        Returns all of the cookies.
+        """
+        raise NotImplementedError
+
     def __getitem__(self, item):
         raise NotImplementedError
 

--- a/splinter/driver/webdriver/chrome.py
+++ b/splinter/driver/webdriver/chrome.py
@@ -7,7 +7,7 @@
 from selenium.webdriver import Chrome
 from selenium.webdriver.chrome.options import Options
 from splinter.driver.webdriver import BaseWebDriver, WebDriverElement
-from splinter.driver.webdriver.cookie_manager import ChromeCookieManager
+from splinter.driver.webdriver.cookie_manager import CookieManager
 
 
 class WebDriver(BaseWebDriver):
@@ -24,6 +24,6 @@ class WebDriver(BaseWebDriver):
 
         self.element_class = WebDriverElement
 
-        self._cookie_manager = ChromeCookieManager(self.driver)
+        self._cookie_manager = CookieManager(self.driver)
 
         super(WebDriver, self).__init__(wait_time)

--- a/splinter/driver/webdriver/cookie_manager.py
+++ b/splinter/driver/webdriver/cookie_manager.py
@@ -23,6 +23,9 @@ class CookieManager(CookieManagerAPI):
         else:
             self.driver.delete_all_cookies()
 
+    def all(self):
+        return self.driver.get_cookies()
+
     def __getitem__(self, item):
         return self.driver.get_cookie(item)['value']
 
@@ -33,38 +36,3 @@ class CookieManager(CookieManagerAPI):
 
         if isinstance(other_object, dict):
             return dict(cookies) == other_object
-
-
-class ChromeCookieManager(CookieManager):
-    """
-    This class exists because of a bug on Chrome webdriver.
-
-    When you call ``driver.delete_cookie(<cookie-identifier>)`` in ChromeDriver, all cookies are deleted.
-
-    We've filled the issue #2262 on Selenium project and we should delete this class when the issue is solved.
-
-    Link to issue: http://code.google.com/p/selenium/issues/detail?id=2262
-    """
-
-    def __init__(self, driver):
-        super(ChromeCookieManager, self).__init__(driver)
-        self._cookies = {}
-
-    def add(self, cookies):
-        super(ChromeCookieManager, self).add(cookies)
-        self._cookies.update(cookies)
-
-    def delete(self, *cookies):
-        for cookie in cookies:
-            try:
-                del self._cookies[cookie]
-            except KeyError:
-                pass
-
-        self.driver.delete_all_cookies()
-
-        # Just delete all cookies
-        if not cookies:
-            self._cookies = {}
-
-        self.add(self._cookies)

--- a/tests/cookies.py
+++ b/tests/cookies.py
@@ -4,6 +4,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+from fake_webapp import EXAMPLE_APP
 
 class CookiesTest(object):
 
@@ -40,3 +41,12 @@ class CookiesTest(object):
         self.browser.cookies.add({'foo': 'bar'})
         self.browser.cookies.delete('mwahahahaha')
         self.assertEqual(self.browser.cookies, {'foo': 'bar'})
+
+    def test_create_and_get_all_cookies(self):
+        "should be able to create some cookies and retrieve them all"
+        self.browser.cookies.delete()
+        self.browser.cookies.add({'taco': 'shrimp'})
+        self.browser.cookies.add({'lavar': 'burton'})
+        self.assertEqual(len(self.browser.cookies.all()), 2)
+        self.browser.cookies.delete()
+        self.assertEqual(self.browser.cookies.all(), [])

--- a/tests/fake_webapp.py
+++ b/tests/fake_webapp.py
@@ -15,7 +15,7 @@ this_folder = path.abspath(path.dirname(__file__))
 def read_static(static_name):
     return open(path.join(this_folder, 'static', static_name)).read()
 
-EXAMPLE_APP = "http://localhost:5000/"
+EXAMPLE_APP = "http://127.0.0.1:5000/"
 EXAMPLE_HTML = read_static('index.html')
 EXAMPLE_IFRAME_HTML = read_static('iframe.html')
 EXAMPLE_ALERT_HTML = read_static('alert.html')


### PR DESCRIPTION
Addresses #240

...CookieManager as this does not appear to be an issue any longer.

This commit also addresses issues with Chrome resolving 'localhost' to 127.0.0.1 when setting/getting cookie data. This obviously causes problems when trying to test so the fake app now uses 127.0.0.1 explicitly instead of localhost.
