### PR TITLE
Handle "internet explorer" as remote driver

### DIFF
--- a/splinter/driver/webdriver/remote.py
+++ b/splinter/driver/webdriver/remote.py
@@ -17,7 +17,11 @@ class WebDriver(BaseWebDriver):
     DEFAULT_URL = 'http://127.0.0.1:4444/wd/hub'
 
     def __init__(self, url=DEFAULT_URL, browser='firefox', wait_time=2, **ability_args):
-        abilities = getattr(DesiredCapabilities, browser.upper(), {})
+        browsername = browser.upper()
+        # Handle case where user specifies IE with a space in it
+        if browsername == 'INTERNET EXPLORER':
+            browsername = 'INTERNETEXPLORER'
+        abilities = getattr(DesiredCapabilities, browsername, {})
         abilities.update(ability_args)
         self.driver = Remote(url, abilities)
 


### PR DESCRIPTION
This change allows the user to specify "internet explorer" (with a
space) as the browser with the remote web driver.

The motivation for this is the Sauce OnDemand Jenkins plugin:
https://wiki.jenkins-ci.org/display/JENKINS/Sauce+OnDemand+Plugin

This plugin sets various environment variables that relate to
Selenium, including:
- SELENIUM_PLATFORM
- SELENIUM_BROWSER
- SELENIUM_VERSION

For the most part, you can pass these directly to splinter.Browser:

```
url = ...
browser = Browser(drive_name="remote",
                  url=url,
                  name="My test",
                  browser=os.environ['SELENIUM_BROWSER'],
                  platform=os.environ['SELENIUM_PLATFORM'],
                  version=os.environ['SELENIUM_VERSION'])
```

The problem is that, for internet explorer, this plugin sets

```
SELENIUM_BROWSER='internet explorer'
```
