### PR TITLE
Fixes problem in find_by_name()

### DIFF
--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -152,6 +152,8 @@ class ZopeTestBrowser(DriverAPI):
                 index += 1
             except IndexError:
                 break
+            except LookupError:
+                break
         return ElementList([ZopeTestBrowserControlElement(element, self) for element in elements], find_by="name", query=name)
 
     def find_link_by_text(self, text):


### PR DESCRIPTION
getControl throws LookupErrors when index is too high not IndexError.
