### PR TITLE
Fix Python 3 issue with function introspection

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -7,6 +7,7 @@
 import tempfile
 import time
 import re
+import sys
 from contextlib import contextmanager
 
 from selenium.common.exceptions import NoSuchElementException
@@ -15,6 +16,14 @@ from selenium.webdriver.common.action_chains import ActionChains
 from splinter.driver import DriverAPI, ElementAPI
 from splinter.element_list import ElementList
 from splinter.utils import warn_deprecated
+
+
+if sys.version_info[0] > 2:
+    _meth_func = '__func__'
+    _func_name = '__name__'
+else:
+    _meth_func = 'im_func'
+    _func_name = 'func_name'
 
 
 class BaseWebDriver(DriverAPI):
@@ -180,7 +189,7 @@ class BaseWebDriver(DriverAPI):
         elements = None
         end_time = time.time() + self.wait_time
 
-        func_name = finder.im_func.func_name
+        func_name = getattr(getattr(finder, _meth_func), _func_name)
         find_by = original_find or func_name[func_name.rfind('_by_') + 4:]
         query = original_query or selector
 


### PR DESCRIPTION
I have just started using splinter in a Python 3.3 environment and hit a minor stumbling block. In Python 3, the two attributes `im_func` and `func_name` have been renamed to `__func__` and `__name__` respectively. I've looked at solutions used by the _six_ module and within splinter itself. From that I've derive the solution in this PR. I'm happy to change it though, if an alternative solution is preferred. Looking forward to your feedback.

On a side note: splinter is awesome and I really like working with it. Great job! :thumbsup: 
