### PR TITLE
Add link to remote web driver document

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,7 @@ The following drivers open a browser to run your actions:
 
 * :doc:`Chrome WebDriver </drivers/chrome>`
 * :doc:`Firefox WebDriver </drivers/firefox>`
+* :doc:`Remote WebDriver </drivers/remote>`
 
 Headless drivers
 ++++++++++++++++


### PR DESCRIPTION
Looks like the doc index page was missing this link. I was able to follow the example and get Splinter working with the Sauce OnDemand service.
