### PR TITLE
Don't swallow KeyError for driver constructor

### DIFF
--- a/splinter/browser.py
+++ b/splinter/browser.py
@@ -41,6 +41,6 @@ def Browser(driver_name='firefox', *args, **kwargs):
 
     try:
         driver = _DRIVERS[driver_name]
-        return driver(*args, **kwargs)
     except KeyError:
         raise DriverNotFoundError("No driver for %s" % driver_name)
+    return driver(*args, **kwargs)


### PR DESCRIPTION
Previously, if the driver_name was valid, but the driver constructor
raised a KeyError exception, the KeyError exception was swallowed and
a DriverNotFoundError was raised.

This happened to me where the remote driver raised a KeyError
exception because of a problem (missing session ID) but Splinter
misleadingly reported DriverNotFoundError.

This patch changes the scope of the try block so it will only
catch KeyError exceptions that are due to invalid driver names.
