### PR TITLE
More robust find_link_by_partial_text()

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -180,7 +180,7 @@ class BaseWebDriver(DriverAPI):
         return self.find_by_xpath('//a[contains(@href, "%s")]' % partial_href, original_find="link by partial href", original_query=partial_href)
 
     def find_link_by_partial_text(self, partial_text):
-        return self.find_by_xpath('//a[contains(text(), "%s")]' % partial_text, original_find="link by partial text", original_query=partial_text)
+        return self.find_by_xpath('//a[contains(normalize-space(.), "%s")]' % partial_text, original_find="link by partial text", original_query=partial_text)
 
     def find_link_by_text(self, text):
         return self.find_by_xpath('//a[text()="%s"]' % text, original_find="link by text", original_query=text)

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -164,7 +164,7 @@ class ZopeTestBrowser(DriverAPI):
         return self._find_links_by_xpath("//a[contains(@href, '%s')]" % partial_href)
 
     def find_link_by_partial_text(self, partial_text):
-        return self._find_links_by_xpath("//a[contains(text(), '%s')]" % partial_text)
+        return self._find_links_by_xpath("//a[contains(normalize-space(.), '%s')]" % partial_text)
 
     def fill(self, name, value):
         self.find_by_name(name=name).first._control.value = value

--- a/tests/find_elements.py
+++ b/tests/find_elements.py
@@ -86,6 +86,10 @@ class FindElementsTest(object):
         link = self.browser.find_link_by_partial_text('FOO')[0]
         self.assertEqual('http://localhost:5000/foo', link['href'])
 
+    def test_finding_all_links_by_partial_text_complex_contents(self):
+        link = self.browser.find_link_by_partial_text('Complex Link')[0]
+        self.assertEqual('http://localhost:5000/foo', link['href'])
+
     def test_finding_last_element_by_css(self):
         "should find last element by css"
         value = self.browser.find_by_css('h1').last.value

--- a/tests/static/index.html
+++ b/tests/static/index.html
@@ -108,6 +108,12 @@
     <div id="simple_text">my test text</div>
     <div id="text_with_html">another <b>b</b>it of text</div>
     <a href="http://localhost:5000/foo">FOO</a>
+    <a href="http://localhost:5000/foo">
+        <i class="fa fa-fw fa-user"></i>
+        &nbsp;
+        <span>Complex</span>
+        <span style="display: inline;" class="env-DEV">Link</span>
+    </a>
     <a href="http://localhost:5000/foo">A wordier (and last) link to FOO</a>
     <a href="http://localhost:5000/bar">BAR: <span>first bar</span></a>
     <a href="http://localhost:5000/bar">BAR: <span>second bar</span></a>


### PR DESCRIPTION
Make find_link_by_partial_text() be able to find links with
complex markup inside `a` tag, ignoring extra spaces and newlines
between words.

Fixes #230.
