### PR TITLE
Fixes #271 - Added support for Firefox mouseover and mouseout

### DIFF
--- a/docs/mouse-interaction.rst
+++ b/docs/mouse-interaction.rst
@@ -4,13 +4,13 @@
 
 .. meta::
     :description: Mouse interatcion.
-    :keywords: splinter, python, tutorial, documentation, mouse interaction, mouseover, mouseout, doube click, mouse events
+    :keywords: splinter, python, tutorial, documentation, mouse interaction, mouseover, mouseout, double click, mouse events
 
 ++++++++++++++++++
 Mouse interactions
 ++++++++++++++++++
 
-    **Note:** Most mouse interaction currently works only on Chrome driver.
+    **Note:** Most mouse interaction currently works only on Chrome driver and Firefox 27.0.1.
 
 Splinter provides some methods for mouse interactions with elements in the page.
 This feature is useful to test if an element appears on mouse over and

--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -6,7 +6,7 @@
 
 from selenium.webdriver import Firefox
 from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
-from splinter.driver.webdriver import BaseWebDriver, WebDriverElement as BaseWebDriverElement
+from splinter.driver.webdriver import BaseWebDriver, WebDriverElement as WebDriverElement
 from splinter.driver.webdriver.cookie_manager import CookieManager
 
 
@@ -37,21 +37,3 @@ class WebDriver(BaseWebDriver):
         self._cookie_manager = CookieManager(self.driver)
 
         super(WebDriver, self).__init__(wait_time)
-
-
-class WebDriverElement(BaseWebDriverElement):
-
-    def mouse_over(self):
-        """
-        Firefox doesn't support mouseover.
-        """
-        raise NotImplementedError("Firefox doesn't support mouse over")
-
-    def mouse_out(self):
-        """
-        Firefox doesn't support mouseout.
-        """
-        raise NotImplementedError("Firefox doesn't support mouseout")
-
-    mouseover = mouse_over
-    mouseout = mouse_out

--- a/tests/test_webdriver_firefox.py
+++ b/tests/test_webdriver_firefox.py
@@ -50,26 +50,6 @@ class FirefoxBrowserTest(WebDriverTests, unittest.TestCase):
         with Browser('firefox') as internet:
             pass
 
-    def test_mouse_over(self):
-        "Firefox should not support mouseover"
-        with self.assertRaises(NotImplementedError):
-            self.browser.find_by_id('visible').mouse_over()
-
-    def test_mouse_out(self):
-        "Firefox should not support mouseout"
-        with self.assertRaises(NotImplementedError):
-            self.browser.find_by_id('visible').mouse_out()
-
-    def test_mouseover_should_be_an_alias_to_mouse_over(self):
-        "Firefox should not support mouseover"
-        with self.assertRaises(NotImplementedError):
-            self.browser.find_by_id('visible').mouseover()
-
-    def test_mouseout_should_be_an_alias_to_mouse_out_and_be_deprecated(self):
-        "Firefox should not support mouseout"
-        with self.assertRaises(NotImplementedError):
-            self.browser.find_by_id('visible').mouseout()
-
 
 @unittest.skipIf(not firefox_installed(), 'firefox is not installed')
 class FirefoxWithExtensionTest(unittest.TestCase):


### PR DESCRIPTION
Updated the docs to reflect changes
Works with Firefox 27 and Selenium 2.39.0
Updated the tests however, full testsuite is failing because of issues unrelated to these changes
