### PR TITLE
Don't strictly pin Django depencency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
     install_requires=['selenium>=2.39.0'],
     extras_require={'zope.testbrowser': ['zope.testbrowser>=4.0.4',
                                          'lxml>=2.3.6', 'cssselect'],
-                    'django': ['Django==1.6.1', 'lxml>=2.3.6', 'cssselect']},
+                    'django': ['Django>=1.6.1', 'lxml>=2.3.6', 'cssselect']},
     tests_require=['coverage', 'flask'],
 )


### PR DESCRIPTION
So that pip install splinter[django] won't uninstall Django 1.6.2 and later.

Probably consider removing Django dependency to enable installing dev version from github (master) with splinter[django]?
