### PR TITLE
Corrected programming language classifiers to exclude Python 3.0, 3.1 and 3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     classifiers=[
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
-    ] + [('Programming Language :: Python :: %s' % x) for x in '2.6 2.7 3.0 3.1 3.2 3.3'.split()],
+    ] + [('Programming Language :: Python :: %s' % x) for x in '2.6 2.7 3.3 3.4'.split()],
     packages=find_packages(exclude=['docs', 'tests', 'samples']),
     include_package_data=True,
     install_requires=['selenium>=2.39.0'],


### PR DESCRIPTION
Hello there,

This is a tiny pull request to ensure that the correct versions of Python are listed in the classifiers section of setup.py and PyPi.  The package is currently being tested and is compatible with Python 2.7 and 3.3.

I have also tested it with a very minor change (use unittest2) on Python 2.6 and can confirm that it is also Python 2.6 compatible.  I'll be submitting a pull request soon to correct the tests for Python 2.6, but the library itself is fully Python 2.6 compatible already.

Cheers
Fotis
