### PR TITLE
Added support for custom headers in PhantomJS driver.

### DIFF
--- a/splinter/driver/webdriver/phantomjs.py
+++ b/splinter/driver/webdriver/phantomjs.py
@@ -17,11 +17,15 @@ class WebDriver(BaseWebDriver):
     element_class = WebDriverElement
 
     def __init__(self, user_agent=None, load_images=True,
-                 desired_capabilities=None, wait_time=2, **kwargs):
+                 desired_capabilities=None, wait_time=2,
+                 custom_headers={}, **kwargs):
         capabilities = DesiredCapabilities.PHANTOMJS.copy()
         if user_agent is not None:
             capabilities['phantomjs.page.settings.userAgent'] = user_agent
         capabilities['phantomjs.page.settings.loadImages'] = load_images
+        if isinstance(custom_headers, dict):
+            for name, value in custom_headers.items():
+                capabilities['phantomjs.page.customHeaders.%s' % name] = value
         if desired_capabilities:
             capabilities.update(desired_capabilities)
 

--- a/tests/fake_webapp.py
+++ b/tests/fake_webapp.py
@@ -96,6 +96,11 @@ def upload_file():
         return '|'.join(buffer)
 
 
+@app.route('/headers', methods=['GET'])
+def request_headers():
+    return str(request.headers)
+
+
 @app.route('/foo')
 def foo():
     return "BAR!"

--- a/tests/test_webdriver_phantomjs.py
+++ b/tests/test_webdriver_phantomjs.py
@@ -53,3 +53,23 @@ class PhantomJSBrowserTest(WebDriverTests, unittest.TestCase):
         # FIXME: Check https://github.com/detro/ghostdriver/issues/180 to see if
         # we can implement this test
         pass
+
+
+class PhantomJSBrowserTestWithCustomHeaders(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        custom_headers = {'X-Splinter-Customheaders-1': 'Hello',
+                          'X-Splinter-Customheaders-2': 'Bye'}
+        cls.browser = Browser("phantomjs", custom_headers=custom_headers)
+
+    def test_create_a_phantomjs_with_custom_headers(self):
+        self.browser.visit(EXAMPLE_APP + 'headers')
+        self.assertTrue(
+            self.browser.is_text_present('X-Splinter-Customheaders-1: Hello'))
+        self.assertTrue(
+            self.browser.is_text_present('X-Splinter-Customheaders-2: Bye'))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.browser.quit()


### PR DESCRIPTION
I'd like to test web applications supporting multiple languages.
To do so, additional request headers like 'Accept-Language: en-US,en;q=0.8,ja;q=0.6' is required to be set in HTTP request message.

This patch allows PhantomJS driver to send custom headers to the web apps, by specifying 'custom_headers' parameter in dict format when creating Browser instance.

Also, please note that it requires phantomjs >=1.9.2.
