### PR TITLE
Add `select_by_text` methods

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -460,6 +460,9 @@ class BaseWebDriver(DriverAPI):
     def select(self, name, value):
         self.find_by_xpath('//select[@name="%s"]//option[@value="%s"]' % (name, value)).first._element.click()
 
+    def select_by_text(self, name, text):
+        self.find_by_xpath('//select[@name="%s"]/option[text()="%s"]' % (name, text)).first._element.click()
+
     def quit(self):
         self.driver.quit()
 
@@ -515,6 +518,9 @@ class WebDriverElement(ElementAPI):
     def select(self, value):
         self.find_by_xpath(
             '//select[@name="%s"]/option[@value="%s"]' % (self["name"], value))._element.click()
+
+    def select_by_text(self, text):
+        self.find_by_xpath('//select[@name="%s"]/option[text()="%s"]' % (self["name"], text))._element.click()
 
     def type(self, value, slowly=False):
         if slowly:

--- a/tests/base.py
+++ b/tests/base.py
@@ -189,3 +189,9 @@ class WebDriverTests(BaseBrowserTests, IFrameElementsTest, ElementDoestNotExistT
         with self.browser.get_alert() as alert:
             self.assertEqual('This is an alert example.', alert.text)
             alert.accept()
+
+    def test_can_select_a_option_via_element_text(self):
+        "should provide a way to select a option via element"
+        self.assertFalse(self.browser.find_option_by_value("rj").selected)
+        self.browser.find_by_name("uf").select_by_text("Rio de Janeiro")
+        self.assertTrue(self.browser.find_option_by_value("rj").selected)


### PR DESCRIPTION
With select option lists, it is more convenient to select them by their
(visible) text.

Let me know if you find this useful, and I will add tests.