### PR TITLE
Updated install doc to remove Python 2.5 as target

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -13,7 +13,7 @@ Install guide
 Install Python
 ==============
 
-In order to install Splinter, make sure Python is installed. Note: only Python 2.6 and 2.7 are supported. Version 3.x is not supported yet.
+In order to install Splinter, make sure Python is installed. Note: only Python 2.7+ is supported.
 
 Download Python from http://www.python.org. If you’re using Linux or Mac OS X, it is probably already installed.
 


### PR DESCRIPTION
According to https://github.com/cobrateam/splinter/commit/75c0ec1b2a115eb361ccd5228ba0ddfc2f9e0984 support for Python 2.5 has been dropped. Here I've also generalized Python 3.0 to 3.x ... which might now be supported?
