### PR TITLE
Selenium deprecated 'switch_to_frame'

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -282,11 +282,11 @@ class BaseWebDriver(DriverAPI):
 
     @contextmanager
     def get_iframe(self, id):
-        self.driver.switch_to_frame(id)
+        self.driver.switch_to.frame(id)
         try:
             yield self
         finally:
-            self.driver.switch_to_frame(None)
+            self.driver.switch_to.frame(None)
 
     def find_option_by_value(self, value):
         return self.find_by_xpath('//option[@value="%s"]' % value, original_find="option by value", original_query=value)


### PR DESCRIPTION
WebDriver's `switch_to_frame` has been deprecated and changed to `driver.switch_to.frame` so I updated the only place where `switch_to_frame` is used, the `get_iframe` function. All of the existing tests I ran via `make test` were unaffected by this change. There is no real behavior change other than the warning's output is now suppressed.

https://github.com/SeleniumHQ/selenium/blob/31c41534e30f0d6f38f3289f36bda347e5a8c15d/py/selenium/webdriver/remote/webdriver.py#L503
