### PR TITLE
Fix Firefox form test

### DIFF
--- a/tests/form_elements.py
+++ b/tests/form_elements.py
@@ -13,8 +13,8 @@ class FormElementsTest(object):
         self.assertEqual('new query', value)
 
     def test_should_provide_a_method_on_element_to_change_its_value(self):
-        self.browser.find_by_name('query').fill('new query')
-        value = self.browser.find_by_name('query').value
+        self.browser.find_by_name('q').fill('new query')
+        value = self.browser.find_by_name('q').value
         self.assertEqual('new query', value)
 
     def test_submiting_a_form_and_verifying_page_content(self):

--- a/tests/static/index.html
+++ b/tests/static/index.html
@@ -78,6 +78,7 @@
     <h1 id="firstheader">Example Last Header</h1>
     <form action="name" method="GET">
         <label for="query">Query</label>
+        <input type="text" name="q" />
         <input type="text" name="query" value="default value" />
         <input type="text" name="query" value="default last value" />
         <input type="password" name="password" />


### PR DESCRIPTION
It appears that the multiple inputs with identical `name` values are confusing Firefox in this particular test.  Since this test has really nothing to do with such a situation (it merely shows that we can fill in a text field), I have moved it to a new, uniquely "named" input.
