### PR TITLE
In case of StaleElementReferenceException, refresh the browser

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -257,6 +257,9 @@ class BaseWebDriver(DriverAPI):
                 return True
             except ValueError:
                 pass
+            except StaleElementReferenceException:
+                self.reload()
+                pass
             except NoSuchElementException:
                 # This exception will be thrown if the body tag isn't present
                 # This has occasionally been observed. Assume that the

--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -10,7 +10,7 @@ import re
 import sys
 from contextlib import contextmanager
 
-from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import NoSuchElementException, StaleElementReferenceException
 from selenium.webdriver.common.action_chains import ActionChains
 
 from splinter.driver import DriverAPI, ElementAPI


### PR DESCRIPTION
Occasionnaly, the function `is_text_present` may throw a `StaleElementReferenceException` due to a DOM change. This PR catches the exception and is issuing a browser refresh.
