### PR TITLE
Add selection option by text to the element api

### DIFF
--- a/splinter/driver/__init__.py
+++ b/splinter/driver/__init__.py
@@ -556,5 +556,15 @@ class ElementAPI(InheritedDocs('_ElementAPI', (object,), {})):
         """
         raise NotImplementedError
 
+    def select_option_by_text(self, value):
+          """
+          Selects an ``<option>`` element in the element using the ``text`` of the ``<option>``.
+
+          Example:
+
+              >>>element..select_option_by_text("New York")
+          """
+          raise NotImplementedError
+
     def __getitem__(self, attribute):
         raise NotImplementedError

--- a/splinter/driver/__init__.py
+++ b/splinter/driver/__init__.py
@@ -562,7 +562,7 @@ class ElementAPI(InheritedDocs('_ElementAPI', (object,), {})):
 
           Example:
 
-              >>>element..select_option_by_text("New York")
+              >>> element.select_option_by_text("New York")
           """
           raise NotImplementedError
 

--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -400,6 +400,9 @@ class DjangoClientControlElement(DjangoClientElement):
     def select(self, value):
         self._control.value = value
 
+    def select_option_by_text(self, value):
+        self._control.value = self._control.xpath('.//option[normalize-space(.) = "%s"]' % value)[0].values()[0]
+
     def _get_parent_form(self):
         parent_form = next(self._control.iterancestors('form'))
         return self.parent._forms.setdefault(parent_form._name(), parent_form)

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -400,6 +400,9 @@ class FlaskClientControlElement(FlaskClientElement):
     def select(self, value):
         self._control.value = value
 
+    def select_option_by_text(self, value):
+        self._control.value = self._control.xpath('.//option[normalize-space(.) = "%s"]' % value)[0].values()[0]
+
     def _get_parent_form(self):
         parent_form = next(self._control.iterancestors('form'))
         return self.parent._forms.setdefault(parent_form._name(), parent_form)

--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -458,7 +458,7 @@ class WebDriverElement(ElementAPI):
         self.find_by_xpath('//select[@name="%s"]/option[@value="%s"]' % (self["name"], value))._element.click()
 
     def select_option_by_text(self, value):
-        self.find_by_xpath('.//option[normalize-space(.) = %s]' % value)._element.click()
+        self.find_by_xpath('.//option[normalize-space(.) = "%s"]' % value)._element.click()
  
     def type(self, value, slowly=False):
         if slowly:

--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -457,6 +457,9 @@ class WebDriverElement(ElementAPI):
     def select(self, value):
         self.find_by_xpath('//select[@name="%s"]/option[@value="%s"]' % (self["name"], value))._element.click()
 
+    def select_option_by_text(self, value):
+        self.find_by_xpath('.//option[normalize-space(.) = %s]' % value)._element.click()
+ 
     def type(self, value, slowly=False):
         if slowly:
             return TypeIterator(self._element, value)

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -343,6 +343,7 @@ class ZopeTestBrowserControlElement(ZopeTestBrowserElement):
     def __init__(self, control, parent):
         self._control = control
         self.parent = parent
+        self._element = control
 
     def __getitem__(self, attr):
         return self._control.mech_control.attrs[attr]
@@ -366,6 +367,10 @@ class ZopeTestBrowserControlElement(ZopeTestBrowserElement):
 
     def select(self, value):
         self._control.value = [value]
+
+    def select_option_by_text(self, value):
+        display_value = filter(lambda option: option == value, [option for option in self._control.displayOptions])
+        self._control.displayValue = display_value
 
 class ZopeTestBrowserOptionElement(ZopeTestBrowserElement):
 

--- a/tests/form_elements.py
+++ b/tests/form_elements.py
@@ -40,6 +40,13 @@ class FormElementsTest(object):
         "should provide a way to find select option by text"
         self.assertEqual("rj", self.browser.find_option_by_text("Rio de Janeiro").value)
 
+    def test_can_select_option_by_text(self):
+        "should provide a way to select option by text within an element"
+        self.assertFalse(self.browser.find_option_by_value("rj").selected)
+        element = self.browser.find_by_name('uf')[0]
+        element.select_option_by_text("Rio de Janeiro")
+        self.assertTrue(self.browser.find_option_by_value("rj").selected)
+
     def test_can_select_a_option(self):
         "should provide a way to select a option"
         self.assertFalse(self.browser.find_option_by_value("rj").selected)


### PR DESCRIPTION
This pull request adds a select option by text to the element api. This resolves an issue wherein you are unable to select an option by text because the value occurs before the current element in a different element. (EX. Two state dropdowns on a page with the same values)
