### PR TITLE
added ignore_robots flag to zope.testbrowser

### DIFF
--- a/docs/drivers/zope.testbrowser.rst
+++ b/docs/drivers/zope.testbrowser.rst
@@ -33,6 +33,15 @@ the ``Browser`` instance:
     from splinter import Browser
     browser = Browser('zope.testbrowser')
 
+By default ``zope.testbrowser`` respects any robots.txt preventing access to a lot of sites. If you want to circumvent
+this you can call
+
+.. highlight:: python
+
+::
+
+    browser = Browser('zope.testbrowser', ignore_robots=True)
+
 **Note:** if you don't provide any driver to ``Browser`` function, ``firefox`` will be used.
 
 API docs

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -61,9 +61,9 @@ class ZopeTestBrowser(DriverAPI):
 
     driver_name = "zope.testbrowser"
 
-    def __init__(self, user_agent=None, wait_time=2):
+    def __init__(self, user_agent=None, wait_time=2, ignore_robots=False):
         self.wait_time = wait_time
-        mech_browser = self._get_mech_browser(user_agent)
+        mech_browser = self._get_mech_browser(user_agent, ignore_robots)
         self._browser = Browser(mech_browser=mech_browser)
 
         self._cookie_manager = CookieManager(self._browser.cookies)
@@ -258,10 +258,15 @@ class ZopeTestBrowser(DriverAPI):
     def _element_is_control(self, element):
         return hasattr(element, 'type')
 
-    def _get_mech_browser(self, user_agent):
+    def _get_mech_browser(self, user_agent, ignore_robots):
         mech_browser = mechanize.Browser()
+
         if user_agent is not None:
             mech_browser.addheaders = [("User-agent", user_agent), ]
+
+        if ignore_robots:
+            mech_browser.set_handle_robots(False)
+
         return mech_browser
 
     @property


### PR DESCRIPTION
Otherwise there was no possibility to tell the mechanize browser that is used by the zope.testbrowser driver to ignore robots.txt