### PR TITLE
Update to indicate that get_iframe() can be used with other attributes..

### DIFF
--- a/docs/iframes-and-alerts.rst
+++ b/docs/iframes-and-alerts.rst
@@ -13,7 +13,7 @@ Frames, alerts and prompts
 Using iframes
 -------------
 
-You can use the ``get_iframe`` method and the ``with`` statement to interact with iframes.
+You can use the ``get_iframe`` method and the ``with`` statement to interact with iframes. You can pass the iframe's name, id, or index to ``get_iframe``.
 
 .. highlight:: python
 


### PR DESCRIPTION
...than name.

The implementation of get_iframe(name) should probably be updated so it doesn't imply that only name can be used.