### PR TITLE
Use a minimum selenium version; easier to update selenium in parent packages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     ] + [('Programming Language :: Python :: %s' % x) for x in '2.6 2.7 3.3 3.4'.split()],
     packages=find_packages(exclude=['docs', 'tests', 'samples']),
     include_package_data=True,
-    install_requires=['selenium==2.44.0'],
+    install_requires=['selenium>=2.44.0'],
     extras_require={'zope.testbrowser': ['zope.testbrowser>=4.0.4',
                                          'lxml>=2.3.6', 'cssselect'],
                     'django': ['Django>=1.5.8,<1.7', 'lxml>=2.3.6', 'cssselect'],


### PR DESCRIPTION
Newer firefox versions often break with older selenium.