### PR TITLE
Return decoded text strings for title and html.

### DIFF
--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -141,17 +141,17 @@ class DjangoClient(DriverAPI):
         try:
             return self._html
         except AttributeError:
-            self._html = lxml.html.fromstring(self.html.decode('utf-8'))
+            self._html = lxml.html.fromstring(self.html)
             return self._html
 
     @property
     def title(self):
         html = self.htmltree
-        return html.xpath('//title')[0].text_content().strip().encode('utf-8')
+        return html.xpath('//title')[0].text_content().strip()
 
     @property
     def html(self):
-        return self._response.content
+        return self._response.content.decode(self._response.charset)
 
     @property
     def url(self):

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -132,17 +132,17 @@ class FlaskClient(DriverAPI):
         try:
             return self._html
         except AttributeError:
-            self._html = lxml.html.fromstring(self.html.decode('utf-8'))
+            self._html = lxml.html.fromstring(self.html)
             return self._html
 
     @property
     def title(self):
         html = self.htmltree
-        return html.xpath('//title')[0].text_content().strip().encode('utf-8')
+        return html.xpath('//title')[0].text_content().strip()
 
     @property
     def html(self):
-        return self._response.data
+        return self._response.get_data(as_text=True)
 
     @property
     def url(self):

--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -166,17 +166,11 @@ class BaseWebDriver(DriverAPI):
 
     @property
     def title(self):
-        if sys.version_info[0] > 2:
-            return self.driver.title.encode('utf-8')
-        else:
-            return self.driver.title
+        return self.driver.title
 
     @property
     def html(self):
-        if sys.version_info[0] > 2:
-            return self.driver.page_source.encode('utf-8')
-        else:
-            return self.driver.page_source
+        return self.driver.page_source
 
     @property
     def url(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -32,7 +32,7 @@ class BaseBrowserTests(ElementTest, FindElementsTest, FormElementsTest, ClickEle
     def test_can_open_page(self):
         "should be able to visit, get title and quit"
         title = self.browser.title
-        self.assertEqual(b'Example Title', title)
+        self.assertEqual('Example Title', title)
 
     def test_can_back_on_history(self):
         "should be able to back on history"
@@ -51,14 +51,14 @@ class BaseBrowserTests(ElementTest, FindElementsTest, FormElementsTest, ClickEle
     def test_should_have_html(self):
         "should have access to the html"
         html = self.browser.html
-        assert b'<title>Example Title</title>' in html
-        assert b'<h1 id="firstheader">Example Header</h1>' in html
+        assert '<title>Example Title</title>' in html
+        assert '<h1 id="firstheader">Example Header</h1>' in html
 
     def test_should_reload_a_page(self):
         "should reload a page"
         title = self.browser.title
         self.browser.reload()
-        self.assertEqual(b'Example Title', title)
+        self.assertEqual('Example Title', title)
 
     def test_should_have_url(self):
         "should have access to the url"

--- a/tests/click_elements.py
+++ b/tests/click_elements.py
@@ -10,34 +10,34 @@ class ClickElementsTest(object):
     def test_click_links(self):
         "should allow to click links"
         self.browser.find_link_by_text('FOO').click()
-        assert b'BAR!' in self.browser.html
+        assert 'BAR!' in self.browser.html
 
     def test_click_element_by_css_selector(self):
         "should allow to click at elements by css selector"
         self.browser.find_by_css('a[href="http://localhost:5000/foo"]').click()
-        assert b'BAR!' in self.browser.html
+        assert 'BAR!' in self.browser.html
 
     def test_click_input_by_css_selector(self):
         "should allow to click at inputs by css selector"
         self.browser.find_by_css('input[name="send"]').click()
-        assert b'My name is: Master Splinter' in self.browser.html
+        assert 'My name is: Master Splinter' in self.browser.html
 
     def test_click_link_by_href(self):
         "should allow to click link by href"
         self.browser.click_link_by_href('http://localhost:5000/foo')
-        assert b"BAR!" in self.browser.html
+        assert "BAR!" in self.browser.html
 
     def test_click_link_by_partial_href(self):
         "should allow to click link by partial href"
         self.browser.click_link_by_partial_href('5000/foo')
-        assert b"BAR!" in self.browser.html
+        assert "BAR!" in self.browser.html
 
     def test_click_link_by_text(self):
         "should allow to click link by text"
         self.browser.click_link_by_text('FOO')
-        assert b"BAR!" in self.browser.html
+        assert "BAR!" in self.browser.html
 
     def test_click_link_by_partial_text(self):
         "should allow to click link by partial text"
         self.browser.click_link_by_partial_text("wordier")
-        assert b"BAR!" in self.browser.html
+        assert "BAR!" in self.browser.html

--- a/tests/form_elements.py
+++ b/tests/form_elements.py
@@ -21,7 +21,7 @@ class FormElementsTest(object):
     def test_submiting_a_form_and_verifying_page_content(self):
         self.browser.fill('query', 'my name')
         self.browser.find_by_name('send').click()
-        assert b'My name is: Master Splinter' in self.browser.html
+        assert 'My name is: Master Splinter' in self.browser.html
 
     def test_can_choose_a_radio_button(self):
         "should provide a way to choose a radio button"

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -39,7 +39,7 @@ class BrowserTest(unittest.TestCase):
         from splinter import Browser
         browser = Browser(driver_name=webdriver, user_agent="iphone")
         browser.visit(EXAMPLE_APP + "useragent")
-        result = b'iphone' in browser.html
+        result = 'iphone' in browser.html
         browser.quit()
 
         return result

--- a/tests/test_djangoclient.py
+++ b/tests/test_djangoclient.py
@@ -47,7 +47,7 @@ class DjangoClientDriverTest(BaseBrowserTests, unittest.TestCase):
         self.browser.find_by_name('upload').click()
 
         html = self.browser.html
-        assert b'text/plain' in html
+        assert 'text/plain' in html
         assert open(file_path).read().encode('utf-8') in html
 
     def test_forward_to_none_page(self):

--- a/tests/test_flaskclient.py
+++ b/tests/test_flaskclient.py
@@ -39,7 +39,7 @@ class FlaskClientDriverTest(BaseBrowserTests, unittest.TestCase):
         self.browser.find_by_name('upload').click()
 
         html = self.browser.html
-        assert b'text/plain' in html
+        assert 'text/plain' in html
         assert open(file_path).read().encode('utf-8') in html
 
     def test_forward_to_none_page(self):

--- a/tests/test_webdriver_chrome.py
+++ b/tests/test_webdriver_chrome.py
@@ -45,7 +45,7 @@ class ChromeBrowserTest(WebDriverTests, unittest.TestCase):
         self.browser.find_by_name('upload').click()
 
         html = self.browser.html
-        assert b'text/plain' in html
+        assert 'text/plain' in html
         assert open(file_path).read().encode('utf-8') in html
 
     def test_should_support_with_statement(self):

--- a/tests/test_webdriver_firefox.py
+++ b/tests/test_webdriver_firefox.py
@@ -44,7 +44,7 @@ class FirefoxBrowserTest(WebDriverTests, unittest.TestCase):
         self.browser.find_by_name('upload').click()
 
         html = self.browser.html
-        assert b'text/plain' in html
+        assert 'text/plain' in html
         assert open(file_path).read().encode('utf-8') in html
 
     def test_should_support_with_statement(self):

--- a/tests/test_zopetestbrowser.py
+++ b/tests/test_zopetestbrowser.py
@@ -42,7 +42,7 @@ class ZopeTestBrowserDriverTest(BaseBrowserTests, unittest.TestCase):
         self.browser.find_by_name('upload').click()
 
         html = self.browser.html
-        assert b'text/plain' in html
+        assert 'text/plain' in html
         assert open(file_path).read().encode('utf-8') in html
 
     def test_forward_to_none_page(self):


### PR DESCRIPTION
See discussion on #165 - this essentially takes the inverse approach to #304 so that titles and html source are text strings rather than byte strings which makes writing tests feel much more natural.