### PR TITLE
add driver cookies to request handler connection

### DIFF
--- a/splinter/request_handler/request_handler.py
+++ b/splinter/request_handler/request_handler.py
@@ -52,6 +52,9 @@ class RequestHandler(object):
         self.conn.putheader('User-agent', 'python/splinter')
         if self.auth:
             self.conn.putheader("Authorization", "Basic %s" % self.auth)
+        if hasattr(self, 'driver') and hasattr(self.driver, 'get_cookies'):
+            cookies = '; '.join(['%s=%s' % (c['name'], c['value']) for c in self.driver.get_cookies()])
+            self.conn.putheader('Cookie', cookies)
         self.conn.endheaders()
 
     def _parse_url(self):


### PR DESCRIPTION
Current visit doesn't really worked if your working with a system where a login is required as the "connect" function [here](https://github.com/cobrateam/splinter/blob/af0054a526756916f15fd26fee6c45c6c5d02336/splinter/driver/webdriver/__init__.py#L180) doesn't have the same cookies as the driver being used otherwise. This fixes that.

I presume we might need tests for this and some other checks before adding the cookies? Let me know what and where and I'll add.
