### PR TITLE
docs: fix broken link to install page on tutorial page

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -10,7 +10,7 @@
 Splinter Tutorial
 +++++++++++++++++
 
-Before starting, make sure Splinter is `installed <http://splinter.readthedocs.org/docs/install.html>`_.
+Before starting, make sure Splinter is :doc:`installed </install>`
 
 This tutorial provides a simple example, teaching step by step how to:
 


### PR DESCRIPTION
The link http://splinter.readthedocs.org/docs/install.html gives a 404