### PR TITLE
SyntaxError

### DIFF
--- a/splinter/element_list.py
+++ b/splinter/element_list.py
@@ -40,7 +40,7 @@ class ElementList(list):
             return super(ElementList, self).__getitem__(index)
         except IndexError:
             raise ElementDoesNotExist(
-                u'no elements could be found with {0} "{1}"'.format(
+                'no elements could be found with {0} "{1}"'.format(
                     self.find_by, self.query))
 
     @property
@@ -71,5 +71,5 @@ class ElementList(list):
         try:
             return getattr(self.first, name)
         except (ElementDoesNotExist, AttributeError):
-            raise AttributeError(u"'{0}' object has no attribute '{1}'".format(
+            raise AttributeError("'{0}' object has no attribute '{1}'".format(
                 self.__class__.__name__, name))


### PR DESCRIPTION
Python Shell (Python 3.2.3) on Raspberry Pi (Raspbian) was throwing an error on "import splinter". I suspect two typos.
