### PR TITLE
Improved support for Chrome in Remote driver

### DIFF
--- a/splinter/driver/webdriver/remote.py
+++ b/splinter/driver/webdriver/remote.py
@@ -25,7 +25,10 @@ class WebDriver(BaseWebDriver):
         abilities.update(ability_args)
         self.driver = Remote(url, abilities)
 
-        self.element_class = WebDriverElement
+        if browsername == 'CHROME':
+            self.element_class = BaseWebDriverElement
+        else:
+            self.element_class = WebDriverElement
 
         self._cookie_manager = CookieManager(self.driver)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -21,6 +21,7 @@ from .status_code import StatusCodeTest
 from .screenshot import ScreenshotTest
 from .type import SlowlyTypeTest
 from .popups import PopupWindowsTest
+import time
 
 
 class BaseBrowserTests(ElementTest, FindElementsTest, FormElementsTest, ClickElementsTest,
@@ -125,6 +126,7 @@ class WebDriverTests(BaseBrowserTests, IFrameElementsTest, ElementDoestNotExistT
     def test_access_alerts_and_accept_them(self):
         self.browser.visit(EXAMPLE_APP + 'alert')
         self.browser.find_by_tag('h1').click()
+        time.sleep(0.1)
         alert = self.browser.get_alert()
         self.assertEqual('This is an alert example.', alert.text)
         alert.accept()
@@ -132,12 +134,14 @@ class WebDriverTests(BaseBrowserTests, IFrameElementsTest, ElementDoestNotExistT
     def test_access_prompts_and_be_able_to_fill_then(self):
         self.browser.visit(EXAMPLE_APP + 'alert')
         self.browser.find_by_tag('h2').click()
+        time.sleep(0.1)
 
         alert = self.browser.get_alert()
         self.assertEqual('What is your name?', alert.text)
         alert.fill_with('Splinter')
         alert.accept()
 
+        time.sleep(0.1)
         response = self.browser.get_alert()
         self.assertEqual('Splinter', response.text)
         response.accept()
@@ -146,18 +150,22 @@ class WebDriverTests(BaseBrowserTests, IFrameElementsTest, ElementDoestNotExistT
         self.browser.visit(EXAMPLE_APP + 'alert')
 
         self.browser.find_by_tag('h3').click()
+        time.sleep(0.1)
         alert = self.browser.get_alert()
 
         self.assertEqual('Should I continue?', alert.text)
         alert.accept()
+        time.sleep(0.1)
         alert = self.browser.get_alert()
         self.assertEqual('You say I should', alert.text)
         alert.accept()
 
         self.browser.find_by_tag('h3').click()
+        time.sleep(0.1)
         alert = self.browser.get_alert()
         self.assertEqual('Should I continue?', alert.text)
         alert.dismiss()
+        time.sleep(0.1)
         alert = self.browser.get_alert()
         self.assertEqual('You say I should not', alert.text)
         alert.accept()
@@ -166,18 +174,22 @@ class WebDriverTests(BaseBrowserTests, IFrameElementsTest, ElementDoestNotExistT
         self.browser.visit(EXAMPLE_APP + 'alert')
 
         self.browser.find_by_tag('h3').click()
+        time.sleep(0.1)
         with self.browser.get_alert() as alert:
             self.assertEqual('Should I continue?', alert.text)
             alert.accept()
 
+        time.sleep(0.1)
         with self.browser.get_alert() as alert:
             self.assertEqual('You say I should', alert.text)
             alert.accept()
 
         self.browser.find_by_tag('h3').click()
+        time.sleep(0.1)
         with self.browser.get_alert() as alert:
             self.assertEqual('Should I continue?', alert.text)
             alert.dismiss()
+        time.sleep(0.1)
         with self.browser.get_alert() as alert:
             self.assertEqual('You say I should not', alert.text)
             alert.accept()
@@ -186,6 +198,7 @@ class WebDriverTests(BaseBrowserTests, IFrameElementsTest, ElementDoestNotExistT
         "should access alerts using 'with' statement"
         self.browser.visit(EXAMPLE_APP + 'alert')
         self.browser.find_by_tag('h1').click()
+        time.sleep(0.1)
         with self.browser.get_alert() as alert:
             self.assertEqual('This is an alert example.', alert.text)
             alert.accept()

--- a/tests/click_elements.py
+++ b/tests/click_elements.py
@@ -4,40 +4,48 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+import time
 
 class ClickElementsTest(object):
 
     def test_click_links(self):
         "should allow to click links"
         self.browser.find_link_by_text('FOO').click()
+        time.sleep(0.1)
         assert 'BAR!' in self.browser.html
 
     def test_click_element_by_css_selector(self):
         "should allow to click at elements by css selector"
         self.browser.find_by_css('a[href="http://localhost:5000/foo"]').click()
+        time.sleep(0.1)
         assert 'BAR!' in self.browser.html
 
     def test_click_input_by_css_selector(self):
         "should allow to click at inputs by css selector"
         self.browser.find_by_css('input[name="send"]').click()
+        time.sleep(0.1)
         assert 'My name is: Master Splinter' in self.browser.html
 
     def test_click_link_by_href(self):
         "should allow to click link by href"
         self.browser.click_link_by_href('http://localhost:5000/foo')
+        time.sleep(0.1)
         assert "BAR!" in self.browser.html
 
     def test_click_link_by_partial_href(self):
         "should allow to click link by partial href"
         self.browser.click_link_by_partial_href('5000/foo')
+        time.sleep(0.1)
         assert "BAR!" in self.browser.html
 
     def test_click_link_by_text(self):
         "should allow to click link by text"
         self.browser.click_link_by_text('FOO')
+        time.sleep(0.1)
         assert "BAR!" in self.browser.html
 
     def test_click_link_by_partial_text(self):
         "should allow to click link by partial text"
         self.browser.click_link_by_partial_text("wordier")
+        time.sleep(0.1)
         assert "BAR!" in self.browser.html

--- a/tests/form_elements.py
+++ b/tests/form_elements.py
@@ -4,6 +4,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+import time
 
 class FormElementsTest(object):
 
@@ -21,6 +22,7 @@ class FormElementsTest(object):
     def test_submiting_a_form_and_verifying_page_content(self):
         self.browser.fill('query', 'my name')
         self.browser.find_by_name('send').click()
+        time.sleep(0.1)
         assert 'My name is: Master Splinter' in self.browser.html
 
     def test_can_choose_a_radio_button(self):

--- a/tests/test_webdriver_remote.py
+++ b/tests/test_webdriver_remote.py
@@ -78,26 +78,21 @@ class RemoteBrowserTest(WebDriverTests, unittest.TestCase):
             self.browser.find_by_id('visible').mouseover()
 
     def test_create_and_access_a_cookie(self):
-        "Remote should not support cookies"
-        with self.assertRaises(NotImplementedError):
-            self.browser.cookies.add({'sha': 'zam'})
+        "Remote should support cookies"
+        self.browser.cookies.add({'sha': 'zam'})
 
     def test_create_some_cookies_and_delete_them_all(self):
-        "Remote should not support cookies"
-        with self.assertRaises(NotImplementedError):
-            self.browser.cookies.delete()
+        "Remote should support cookies"
+        self.browser.cookies.delete()
 
     def test_create_and_delete_a_cookie(self):
-        "Remote should not support cookies"
-        with self.assertRaises(NotImplementedError):
-            self.browser.cookies.delete('cookie')
+        "Remote should support cookies"
+        self.browser.cookies.delete('cookie')
 
     def test_create_and_delete_many_cookies(self):
-        "Remote should not support cookies"
-        with self.assertRaises(NotImplementedError):
-            self.browser.cookies.delete('cookie', 'notacookie')
+        "Remote should support cookies"
+        self.browser.cookies.delete('cookie', 'notacookie')
 
     def test_try_to_destroy_an_absent_cookie_and_nothing_happens(self):
-        "Remote should not support cookies"
-        with self.assertRaises(NotImplementedError):
-            self.browser.cookies.delete('mwahahahaha')
+        "Remote should support cookies"
+        self.browser.cookies.delete('mwahahahaha')

--- a/tests/test_webdriver_remote.py
+++ b/tests/test_webdriver_remote.py
@@ -28,7 +28,7 @@ def selenium_server_is_running():
     not selenium_server_is_running(),
     'Skipping the remote webdriver tests'
 )
-class RemoteBrowserTest(WebDriverTests, unittest.TestCase):
+class RemoteBrowserDefaultTest(WebDriverTests, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -95,4 +95,72 @@ class RemoteBrowserTest(WebDriverTests, unittest.TestCase):
 
     def test_try_to_destroy_an_absent_cookie_and_nothing_happens(self):
         "Remote should support cookies"
+        self.browser.cookies.delete('mwahahahaha')
+
+
+@unittest.skipIf(
+    not selenium_server_is_running(),
+    'Skipping the remote webdriver tests'
+)
+class RemoteBrowserChromeTest(WebDriverTests, unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.browser = Browser("remote", browser="chrome")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.browser.quit()
+
+    def setUp(self):
+        self.browser.visit(EXAMPLE_APP)
+
+    def test_support_with_statement(self):
+        "Remote should support with statement"
+        with Browser('remote', browser="chrome") as remote:
+            pass
+
+    def test_mouse_over(self):
+        "Remote chrome should support mouseover"
+        self.browser.find_by_id('visible').mouse_over()
+
+    def test_mouse_out(self):
+        "Remote chrome should support mouseout"
+        self.browser.find_by_id('visible').mouse_out()
+
+    def test_double_click(self):
+        "Remote chrome should support double_click"
+        self.browser.find_by_id('visible').double_click()
+
+    def test_right_click(self):
+        "Remote chrome should support right_click"
+        self.browser.find_by_id('visible').right_click()
+
+    def test_drag_and_drop(self):
+        "Remote chrome should support drag_and_drop"
+        droppable = self.browser.find_by_css('.droppable')
+        self.browser.find_by_css('.draggable').drag_and_drop(droppable)
+
+    def test_mouseover_should_be_an_alias_to_mouse_over(self):
+        "Remote chrome should support mouseover"
+        self.browser.find_by_id('visible').mouseover()
+
+    def test_create_and_access_a_cookie(self):
+        "Remote chrome should support cookies"
+        self.browser.cookies.add({'sha': 'zam'})
+
+    def test_create_some_cookies_and_delete_them_all(self):
+        "Remote chrome should support cookies"
+        self.browser.cookies.delete()
+
+    def test_create_and_delete_a_cookie(self):
+        "Remote chrome should support cookies"
+        self.browser.cookies.delete('cookie')
+
+    def test_create_and_delete_many_cookies(self):
+        "Remote chrome should support cookies"
+        self.browser.cookies.delete('cookie', 'notacookie')
+
+    def test_try_to_destroy_an_absent_cookie_and_nothing_happens(self):
+        "Remote chrome should support cookies"
         self.browser.cookies.delete('mwahahahaha')


### PR DESCRIPTION
Chrome supports cookies, and mouse actions and is also available in the remote driver. Also, a previous commit that enabled cookie support in the remote driver didn't update the corresponding tests. 
This pull request also has a small number of 100ms sleep statements after click events. There seems to be a lot of latency on click events in the Remote driver, and these tiny bits of sleep compensate for the latency. All tests seem to pass now for the Remote driver.

I know sleep statements aren't the best overall, but I figured for tests, it shouldn't be to bad. In the long run, we may want to investigate some latency compensation code in the Remote driver.
