### PR TITLE
Less memory consumption by leaked firefoxes

### DIFF
--- a/docs/drivers/firefox.rst
+++ b/docs/drivers/firefox.rst
@@ -79,6 +79,15 @@ How to use selenium capabilities for Firefox
 You can pass any selenium `read-write DesiredCapabilities parameters <https://code.google.com/p/selenium/wiki/DesiredCapabilities#Read-write_capabilities>`_ for Firefox.
 
 
+How to use specific binary for Firefox
+--------------------------------------
+
+.. highlight:: python
+
+::
+    from splinter import Browser
+    browser = Browser('firefox', firefox_binary_path="/Your/Sekrit/Firefox/Path")
+
 API docs
 --------
 

--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -4,6 +4,9 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+import os, sys
+from subprocess import check_output
+
 from selenium.webdriver import DesiredCapabilities, Firefox
 from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
 from splinter.driver.webdriver import (
@@ -11,7 +14,6 @@ from splinter.driver.webdriver import (
 from splinter.driver.webdriver.cookie_manager import CookieManager
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.action_chains import ActionChains
-
 
 class WebDriver(BaseWebDriver):
 
@@ -44,9 +46,23 @@ class WebDriver(BaseWebDriver):
                 firefox_profile.add_extension(extension)
         
         firefox_binary = None
+        from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
         if firefox_binary_path is not None:
-            from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
             firefox_binary = FirefoxBinary(firefox_path=firefox_binary_path)
+        
+        # Selenium guesses really badly for firefox on os x, so let's guess better
+        standard_firefox_path = "/Applications/Firefox.app/Contents/MacOS/firefox-bin"
+        if firefox_binary_path is None \
+                and sys.platform.startswith('darwin') \
+                and not os.path.isfile(standard_firefox_path):
+            path = check_output(["mdfind", "kMDItemFSName = Firefox.app"]).decode('utf-8').strip()
+            if path != '':
+                if len(path.split()) > 1: # found multiple foxes, just take the first one
+                    # if you need more control, specify manually
+                    # TODO consider some logging?
+                    path = path.split()[0]
+                firefox_binary_path = os.path.join(path, "Contents/MacOS/firefox-bin")
+                firefox_binary = FirefoxBinary(firefox_path=firefox_binary_path)
         
         self.driver = Firefox(firefox_profile,
                               capabilities=firefox_capabilities,

--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -19,7 +19,7 @@ class WebDriver(BaseWebDriver):
 
     def __init__(self, profile=None, extensions=None, user_agent=None,
                  profile_preferences=None, fullscreen=False, wait_time=2,
-                 capabilities=None):
+                 capabilities=None, firefox_binary_path=None):
 
         firefox_profile = FirefoxProfile(profile)
         firefox_profile.set_preference('extensions.logging.enabled', False)
@@ -42,9 +42,15 @@ class WebDriver(BaseWebDriver):
         if extensions:
             for extension in extensions:
                 firefox_profile.add_extension(extension)
-
+        
+        firefox_binary = None
+        if firefox_binary_path is not None:
+            from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
+            firefox_binary = FirefoxBinary(firefox_path=firefox_binary_path)
+        
         self.driver = Firefox(firefox_profile,
-                              capabilities=firefox_capabilities)
+                              capabilities=firefox_capabilities,
+                              firefox_binary=firefox_binary)
 
         if fullscreen:
             ActionChains(self.driver).send_keys(Keys.F11).perform()

--- a/tests/test_webdriver_chrome.py
+++ b/tests/test_webdriver_chrome.py
@@ -15,7 +15,7 @@ from selenium.common.exceptions import WebDriverException
 
 def chrome_installed():
     try:
-        Browser("chrome")
+        Browser("chrome").quit()
     except WebDriverException:
         return False
     return True

--- a/tests/test_webdriver_firefox.py
+++ b/tests/test_webdriver_firefox.py
@@ -144,16 +144,15 @@ def spy_on(an_object, slot_name, spy):
 class FirefoxCustomPathTest(unittest.TestCase):
     
     def test_custom_path_is_set_correctly(self):
-        from splinter.driver.webdriver import firefox
         arguments = {}
         class FakeFox(object):
             def __init__(self, *args, **kwargs):
                 arguments['args'] = args
                 arguments['kwargs'] = kwargs
         
-        sensor = '/some/custom/path'
-        
+        from splinter.driver.webdriver import firefox
         with spy_on(firefox, 'Firefox', FakeFox):
+            sensor = '/some/custom/path'
             browser = Browser('firefox', firefox_binary_path=sensor)
             self.assertEquals(arguments['kwargs']['firefox_binary']._start_cmd, sensor)
     

--- a/tests/test_webdriver_firefox.py
+++ b/tests/test_webdriver_firefox.py
@@ -130,3 +130,30 @@ class FirefoxBrowserFullScreenTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.browser.quit()
+
+from contextlib import contextmanager
+@contextmanager
+def spy_on(an_object, slot_name, spy):
+    original_value = getattr(an_object, slot_name)
+    setattr(an_object, slot_name, spy)
+    try:
+        yield spy
+    finally:
+        setattr(an_object, slot_name, original_value)
+
+class FirefoxCustomPathTest(unittest.TestCase):
+    
+    def test_custom_path_is_set_correctly(self):
+        from splinter.driver.webdriver import firefox
+        arguments = {}
+        class FakeFox(object):
+            def __init__(self, *args, **kwargs):
+                arguments['args'] = args
+                arguments['kwargs'] = kwargs
+        
+        sensor = '/some/custom/path'
+        
+        with spy_on(firefox, 'Firefox', FakeFox):
+            browser = Browser('firefox', firefox_binary_path=sensor)
+            self.assertEquals(arguments['kwargs']['firefox_binary']._start_cmd, sensor)
+    

--- a/tests/test_webdriver_firefox.py
+++ b/tests/test_webdriver_firefox.py
@@ -14,7 +14,7 @@ from .base import WebDriverTests
 
 def firefox_installed():
     try:
-        Browser("firefox")
+        Browser("firefox").quit()
     except OSError:
         return False
     return True


### PR DESCRIPTION
Well, just something small I noticed where I had lots of open leaked fireboxen around after running some of the tests.

It annoyed me, and this way the tests run way quicker on my machine, due to less ram consumption.

What do you think?