### PR TITLE
Added multi-select support to LxmlDriver

### DIFF
--- a/splinter/driver/lxmldriver.py
+++ b/splinter/driver/lxmldriver.py
@@ -37,6 +37,21 @@ class LxmlDriver(DriverAPI):
     def visit(self, url):
         self._do_method('get', url)
 
+    def serialize(self, form):
+        data = {}
+        for k, v in form.fields.items():
+            if v is None:
+                continue
+            if isinstance(v, lxml.html.MultipleSelectOptions):
+                data[k] = [val for val in v]
+            else:
+                data[k] = v
+        for key in form.inputs.keys():
+            input = form.inputs[key]
+            if getattr(input, 'type', '') == 'file' and key in data:
+                data[key] = open(data[key], 'rb')
+        return data
+
     def submit(self, form):
         method = form.attrib.get('method', 'get').lower()
         action = form.attrib.get('action', '')
@@ -45,11 +60,7 @@ class LxmlDriver(DriverAPI):
         else:
             url = self._url
         self._url = url
-        data = dict(((k, v) for k, v in form.fields.items() if v is not None))
-        for key in form.inputs.keys():
-            input = form.inputs[key]
-            if getattr(input, 'type', '') == 'file' and key in data:
-                data[key] = open(data[key], 'rb')
+        data = self.serialize(form)
         self._do_method(method, url, data=data)
         return self._response
 
@@ -190,7 +201,10 @@ class LxmlDriver(DriverAPI):
             elif control_type == 'radio':
                 control.value = value  # [option for option in control.options if option == value]
             elif control_type == 'select':
-                control.value = [value]
+                if isinstance(value, list):
+                    control.value = value
+                else:
+                    control.value = [value]
             else:
                 # text, textarea, password, tel
                 control.value = value

--- a/tests/static/index.html
+++ b/tests/static/index.html
@@ -108,6 +108,11 @@
                 <option value="celery">Celery</option>
             </optgroup>
         </select>
+        <select name="pets" multiple="multiple">
+            <option value="cat">Cat</option>
+            <option value="dog">Dog</option>
+            <option value="fish">Fish</option>
+        </select>
         <label for="description">Description</label>
         <textarea rows="3" cols="50" name="description"></textarea>
     </form>

--- a/tests/test_flaskclient.py
+++ b/tests/test_flaskclient.py
@@ -42,6 +42,13 @@ class FlaskClientDriverTest(BaseBrowserTests, unittest.TestCase):
         assert 'text/plain' in html
         assert open(file_path, 'rb').read().decode('utf-8') in html
 
+    def test_serialize_select_mutiple(self):
+        "should serialize a select with multiple values into a list"
+        self.browser.select('pets', ['cat', 'dog'])
+        form = self.browser.find_by_name('send')._get_parent_form()
+        data = self.browser.serialize(form)
+        assert data['pets'] == ['cat', 'dog']
+
     def test_forward_to_none_page(self):
         "should not fail when trying to forward to none"
         browser = Browser('flask', app=app)


### PR DESCRIPTION
As initially described in #428, we need multi-select support for Flask (i.e. `<select multiple>`). In this PR:

- Added test for serializing a form for a select with multiple values
- Added `serialize` method for testing serialization exclusively
- Added fix for `fill_form` to support accepting multiple values

**Missing:**

- Test for `fill_form` with list coercion. I am not sure why my past self never wrote a test for that