### PR TITLE
Added custom headers support to Flask client

### DIFF
--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -57,10 +57,11 @@ class FlaskClient(LxmlDriver):
 
     driver_name = "flask"
 
-    def __init__(self, app, user_agent=None, wait_time=2):
+    def __init__(self, app, user_agent=None, wait_time=2, custom_headers=None):
         app.config['TESTING'] = True
         self._browser = app.test_client()
         self._cookie_manager = CookieManager(self._browser)
+        self._custom_headers = custom_headers if custom_headers else {}
         super(FlaskClient, self).__init__(wait_time=wait_time)
 
     def __enter__(self):
@@ -80,7 +81,7 @@ class FlaskClient(LxmlDriver):
     def _do_method(self, method, url, data=None):
         self._url = url
         func_method = getattr(self._browser, method.lower())
-        self._response = func_method(url, data=data, follow_redirects=True)
+        self._response = func_method(url, headers=self._custom_headers, data=data, follow_redirects=True)
         self._last_urls.append(url)
         self._post_load()
 

--- a/tests/test_flaskclient.py
+++ b/tests/test_flaskclient.py
@@ -120,3 +120,23 @@ class FlaskClientDriverTest(BaseBrowserTests, unittest.TestCase):
         for key, text in non_ascii_encodings.items():
             link = self.browser.find_link_by_text(text)
             self.assertEqual(key, link['id'])
+
+
+class FlaskClientDriverTestWithCustomHeaders(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        custom_headers = {'X-Splinter-Customheaders-1': 'Hello',
+                          'X-Splinter-Customheaders-2': 'Bye'}
+        cls.browser = Browser('flask', app=app, custom_headers=custom_headers)
+
+    def test_create_a_flask_client_with_custom_headers(self):
+        self.browser.visit(EXAMPLE_APP + 'headers')
+        self.assertTrue(
+            self.browser.is_text_present('X-Splinter-Customheaders-1: Hello'))
+        self.assertTrue(
+            self.browser.is_text_present('X-Splinter-Customheaders-2: Bye'))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.browser.quit()


### PR DESCRIPTION
In our test suite, we need to send a HTML-specific `Accept` header in order to differentiate HTML requests from JSON ones. In order to add support for that, we need custom headers from `splinter's Flask` client. In this PR:

- Added custom header support for Flask client (based off of Django client)
- Added test

**Notes:**

For anyone who wants `0.7.3` compatible support, we wrote that out here:

https://github.com/underdogio/splinter/compare/6993e85...underdogio:e7b81e5