### PR TITLE
Added support for `in` against cookies

### DIFF
--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -49,6 +49,9 @@ class CookieManager(CookieManagerAPI):
     def __getitem__(self, item):
         return self._cookies[item].value
 
+    def __contains__(self, key):
+        return key in self._cookies
+
     def __eq__(self, other_object):
         if isinstance(other_object, dict):
             cookies_dict = dict([(key, morsel.value)

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -46,6 +46,12 @@ class CookieManager(CookieManagerAPI):
         cookies = dict([(c.name, c) for c in self._cookies.cookie_jar])
         return cookies[item].value
 
+    def __contains__(self, key):
+        for cookie in self._cookies.cookie_jar:
+            if cookie.name == key:
+                return True
+        return False
+
     def __eq__(self, other_object):
         if isinstance(other_object, dict):
             cookies_dict = dict([(c.name, c.value)

--- a/splinter/driver/webdriver/cookie_manager.py
+++ b/splinter/driver/webdriver/cookie_manager.py
@@ -48,6 +48,9 @@ class CookieManager(CookieManagerAPI):
     def __getitem__(self, item):
         return self.driver.get_cookie(item)['value']
 
+    def __contains__(self, key):
+        return self.driver.is_cookie_present(key)
+
     def __eq__(self, other_object):
         cookies = {}
         for cookie in self.driver.get_cookies():

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -52,6 +52,9 @@ class CookieManager(CookieManagerAPI):
     def __getitem__(self, item):
         return self._cookies[item]
 
+    def __contains__(self, key):
+        return key in self._cookies
+
     def __eq__(self, other_object):
         if isinstance(other_object, dict):
             return dict(self._cookies) == other_object

--- a/tests/cookies.py
+++ b/tests/cookies.py
@@ -63,3 +63,10 @@ class CookiesTest(object):
         self.assertEqual(len(self.browser.cookies.all()), 2)
         self.browser.cookies.delete()
         self.assertEqual(self.browser.cookies.all(), {})
+
+    def test_create_and_use_contains(self):
+        "should be able to create many cookies at once as dict"
+        cookies = {'sha': 'zam'}
+        self.browser.cookies.add(cookies)
+        self.assertIn('sha', self.browser.cookies)
+        self.assertNotIn('foo', self.browser.cookies)


### PR DESCRIPTION
During our tests, we wanted to assert some cookies were not present. However, `flaskclient` was erroring out since it was accessing a key that didn't exist via `__getitem__`. As documented by `__contains__`, `__getitem__` is invoked when `__contains__` isn't defined.

https://docs.python.org/2/reference/datamodel.html#object.__contains__

```python
self.assertIn('a', browser.cookies)
# Same as `assert 'a' in browser.cookies
self.assertNotIn('b', browser.cookies)
# Same as `assert 'b' not in browser.cookies
```

To remedy that, we wrote out `__contains__` for each of our engines. In this PR:

- Added `in`/`not in` support for cookies via `__contains__`
- Added test