### PR TITLE
extension support for chrome browser

### DIFF
--- a/splinter/driver/webdriver/chrome.py
+++ b/splinter/driver/webdriver/chrome.py
@@ -15,7 +15,7 @@ class WebDriver(BaseWebDriver):
     driver_name = "Chrome"
 
     def __init__(self, user_agent=None, wait_time=2, fullscreen=False,
-                 **kwargs):
+                 extensions=None, **kwargs):
 
         options = Options()
 
@@ -24,6 +24,10 @@ class WebDriver(BaseWebDriver):
 
         if fullscreen:
             options.add_argument('--kiosk')
+        
+        if extensions:
+            for extension in extensions:
+                options.add_extension(extension)
 
         self.driver = Chrome(chrome_options=options, **kwargs)
 

--- a/tests/test_webdriver_chrome.py
+++ b/tests/test_webdriver_chrome.py
@@ -70,3 +70,9 @@ class ChromeBrowserFullscreenTest(WebDriverTests, unittest.TestCase):
     def test_should_support_with_statement(self):
         with Browser('chrome', fullscreen=True) as internet:
             pass
+
+    def test_with_extension(self):
+        extensions = list()
+        extensions.append('does_not_exist.crx')
+        with self.assertRaises(OSError):
+            Browser('chrome', extensions=extensions)


### PR DESCRIPTION
the chrome driver wrapper will pass a list of extensions to the driver that are supposed to be loaded during initialization.
Equal to the handling for firefox in splinter/splinter/driver/webdriver/firefox.py the chrome WebDriver will now have an additional parameter that can contain a list of extensions, that are to be loaded. This parameter is None for default and will only be taken into account, if it is present.
