### PR TITLE
add link to behave-django and behave

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,8 @@ external links
 
 `salad <https://github.com/salad/salad>`_, a nice mix of great BDD ingredients (splinter + `lettuce <http://lettuce.it>`_ integration)
 
+`behave-django <https://github.com/mixxorz/behave-django>`_, BDD testing in Django using `Behave <http://pythonhosted.org/behave/>`_. Works well with splinter.
+
 
 .. image:: https://d2weczhvl823v0.cloudfront.net/cobrateam/splinter/trend.png
    :alt: Bitdeli badge


### PR DESCRIPTION
These are alternatives to lettuce that are more actively maintained, which I use with splinter.