### PR TITLE
Issue 460 define __ne__ for Python 2.7.x compatibility

### DIFF
--- a/splinter/request_handler/status_code.py
+++ b/splinter/request_handler/status_code.py
@@ -16,6 +16,9 @@ class StatusCode(object):
     def __eq__(self, other):
         return self.code == other
 
+    def __ne__(self, other):
+        return self.code != other
+
     def __str__(self):
         return "{} - {}".format(self.code, self.reason)
 

--- a/tests/status_code.py
+++ b/tests/status_code.py
@@ -13,3 +13,8 @@ class StatusCodeTest(object):
         self.browser.visit(EXAMPLE_APP)
         self.assertEqual(200, self.browser.status_code)
         self.assertEqual('200 - OK', str(self.browser.status_code))
+
+    def test_should_visit_error_of_example_app_and_not_get_200_status_code(self):
+        self.browser.visit(EXAMPLE_APP + 'error.html')
+        self.assertNotEqual(200, self.browser.status_code)
+        self.assertEqual('404 - Not Found', str(self.browser.status_code))


### PR DESCRIPTION
According to Python 2.7.x data model [1]:
"There are no implied relationships among the comparison operators. The
truth of x==y does not imply that x!=y is false. Accordingly, when
defining **eq**(), one should also define **ne**() so that the operators
will behave as expected."

[1] https://docs.python.org/2/reference/datamodel.html
