### PR TITLE
Support for is_element_present_by_* in non-javascript drivers.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,6 +96,7 @@ specific docs for each driver):
 * :doc:`Phantomjs WebDriver </drivers/phantomjs>`
 * :doc:`zope.testbrowser </drivers/zope.testbrowser>`
 * :doc:`django client </drivers/django>`
+* :doc:`flask client </drivers/flask>`
 
 Remote driver
 ++++++++++++++

--- a/splinter/driver/element_present.py
+++ b/splinter/driver/element_present.py
@@ -1,0 +1,58 @@
+class ElementPresentMixIn(object):
+    ''' Support is_element_present_by_* methods for non-javascript drivers. '''
+
+    def is_element_present_by_css(self, css_selector, wait_time=None):
+        if wait_time is not None:
+            raise NotImplementedError('Wait time is not supported on non-javascript drivers')
+        return bool(self.find_by_css(css_selector))
+
+    def is_element_not_present_by_css(self, css_selector, wait_time=None):
+        return not self.is_element_present_by_css(css_selector, wait_time)
+
+    def is_element_present_by_xpath(self, xpath, wait_time=None):
+        if wait_time is not None:
+            raise NotImplementedError('Wait time is not supported on non-javascript drivers')
+        return bool(self.find_by_xpath(xpath))
+
+    def is_element_not_present_by_xpath(self, xpath, wait_time=None):
+        return not self.is_element_present_by_xpath(xpath, wait_time)
+
+    def is_element_present_by_tag(self, tag, wait_time=None):
+        if wait_time is not None:
+            raise NotImplementedError('Wait time is not supported on non-javascript drivers')
+        return bool(self.find_by_tag(tag))
+
+    def is_element_not_present_by_tag(self, tag, wait_time=None):
+        return not self.is_element_present_by_tag(tag, wait_time)
+
+    def is_element_present_by_name(self, name, wait_time=None):
+        if wait_time is not None:
+            raise NotImplementedError('Wait time is not supported on non-javascript drivers')
+        return bool(self.find_by_name(name))
+
+    def is_element_not_present_by_name(self, name, wait_time=None):
+        return not self.is_element_present_by_name(name, wait_time)
+
+    def is_element_present_by_value(self, value, wait_time=None):
+        if wait_time is not None:
+            raise NotImplementedError('Wait time is not supported on non-javascript drivers')
+        return bool(self.find_by_value(value))
+
+    def is_element_not_present_by_value(self, value, wait_time=None):
+        return not self.is_element_present_by_value(value, wait_time)
+
+    def is_element_present_by_text(self, text, wait_time=None):
+        if wait_time is not None:
+            raise NotImplementedError('Wait time is not supported on non-javascript drivers')
+        return bool(self.find_by_text(text))
+
+    def is_element_not_present_by_text(self, text, wait_time=None):
+        return not self.is_element_present_by_text(text, wait_time)
+
+    def is_element_present_by_id(self, id, wait_time=None):
+        if wait_time is not None:
+            raise NotImplementedError('Wait time is not supported on non-javascript drivers')
+        return bool(self.find_by_id(id))
+
+    def is_element_not_present_by_id(self, id, wait_time=None):
+        return not self.is_element_present_by_id(id, wait_time)

--- a/splinter/driver/element_present.py
+++ b/splinter/driver/element_present.py
@@ -2,56 +2,42 @@ class ElementPresentMixIn(object):
     ''' Support is_element_present_by_* methods for non-javascript drivers. '''
 
     def is_element_present_by_css(self, css_selector, wait_time=None):
-        if wait_time is not None:
-            raise NotImplementedError('Wait time is not supported on non-javascript drivers')
         return bool(self.find_by_css(css_selector))
 
     def is_element_not_present_by_css(self, css_selector, wait_time=None):
         return not self.is_element_present_by_css(css_selector, wait_time)
 
     def is_element_present_by_xpath(self, xpath, wait_time=None):
-        if wait_time is not None:
-            raise NotImplementedError('Wait time is not supported on non-javascript drivers')
         return bool(self.find_by_xpath(xpath))
 
     def is_element_not_present_by_xpath(self, xpath, wait_time=None):
         return not self.is_element_present_by_xpath(xpath, wait_time)
 
     def is_element_present_by_tag(self, tag, wait_time=None):
-        if wait_time is not None:
-            raise NotImplementedError('Wait time is not supported on non-javascript drivers')
         return bool(self.find_by_tag(tag))
 
     def is_element_not_present_by_tag(self, tag, wait_time=None):
         return not self.is_element_present_by_tag(tag, wait_time)
 
     def is_element_present_by_name(self, name, wait_time=None):
-        if wait_time is not None:
-            raise NotImplementedError('Wait time is not supported on non-javascript drivers')
         return bool(self.find_by_name(name))
 
     def is_element_not_present_by_name(self, name, wait_time=None):
         return not self.is_element_present_by_name(name, wait_time)
 
     def is_element_present_by_value(self, value, wait_time=None):
-        if wait_time is not None:
-            raise NotImplementedError('Wait time is not supported on non-javascript drivers')
         return bool(self.find_by_value(value))
 
     def is_element_not_present_by_value(self, value, wait_time=None):
         return not self.is_element_present_by_value(value, wait_time)
 
     def is_element_present_by_text(self, text, wait_time=None):
-        if wait_time is not None:
-            raise NotImplementedError('Wait time is not supported on non-javascript drivers')
         return bool(self.find_by_text(text))
 
     def is_element_not_present_by_text(self, text, wait_time=None):
         return not self.is_element_present_by_text(text, wait_time)
 
     def is_element_present_by_id(self, id, wait_time=None):
-        if wait_time is not None:
-            raise NotImplementedError('Wait time is not supported on non-javascript drivers')
         return bool(self.find_by_id(id))
 
     def is_element_not_present_by_id(self, id, wait_time=None):

--- a/splinter/driver/lxmldriver.py
+++ b/splinter/driver/lxmldriver.py
@@ -13,11 +13,12 @@ import sys
 import lxml.html
 from lxml.cssselect import CSSSelector
 from splinter.driver import DriverAPI, ElementAPI
+from splinter.driver.element_present import ElementPresentMixIn
 from splinter.element_list import ElementList
 from splinter.exceptions import ElementDoesNotExist
 
 
-class LxmlDriver(DriverAPI):
+class LxmlDriver(ElementPresentMixIn, DriverAPI):
     def __init__(self, user_agent=None, wait_time=2):
         self.wait_time = wait_time
         self._history = []
@@ -370,7 +371,9 @@ class LxmlControlElement(LxmlElement):
         if sys.version_info[0] > 2:
             parent_form.fields[self['name']] = value
         else:
-            parent_form.fields[self['name']] = value.decode('utf-8')
+            if not isinstance(value, unicode):
+                value = value.decode('utf-8')
+            parent_form.fields[self['name']] = value
 
     def select(self, value):
         self._control.value = value

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -11,6 +11,7 @@ from zope.testbrowser.browser import Browser, ListControl
 from splinter.element_list import ElementList
 from splinter.exceptions import ElementDoesNotExist
 from splinter.driver import DriverAPI, ElementAPI
+from splinter.driver.element_present import ElementPresentMixIn
 from splinter.cookie_manager import CookieManagerAPI
 
 import mimetypes
@@ -60,7 +61,7 @@ class CookieManager(CookieManagerAPI):
             return dict(self._cookies) == other_object
 
 
-class ZopeTestBrowser(DriverAPI):
+class ZopeTestBrowser(ElementPresentMixIn, DriverAPI):
 
     driver_name = "zope.testbrowser"
 

--- a/tests/is_element_present_nojs.py
+++ b/tests/is_element_present_nojs.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2015 splinter authors. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+class IsElementPresentNoJSTest(object):
+
+    def test_is_element_present_by_css(self):
+        "should is element present by css verify if element is present"
+        self.assertTrue(self.browser.is_element_present_by_css('h1'))
+
+    def test_is_element_present_by_css_using_a_custom_wait_time(self):
+        "should is element present by css raise NotImplementedError if using a custom wait time"
+        self.assertRaises(NotImplementedError, self.browser.is_element_present_by_css, '.async-element2', wait_time=3)
+
+    def test_is_element_present_by_css_returns_false_if_element_is_not_present(self):
+        "should is element present by css returns False if element is not present"
+        self.assertFalse(self.browser.is_element_present_by_css('.async-elementzz'))
+
+    def test_is_element_not_present_by_css(self):
+        "should is element not present by css verify if element is not present"
+        self.assertTrue(self.browser.is_element_not_present_by_css('.async-element'))
+
+    def test_is_element_not_present_by_css_returns_false_if_element_is_present(self):
+        "should is element not present by css returns False if element is present"
+        self.assertFalse(self.browser.is_element_not_present_by_css('h1'))
+
+    def test_is_element_not_present_by_css_using_a_custom_wait_time(self):
+        "should is element not present by css raise NotImplementedError if using a custom wait time"
+        self.assertRaises(NotImplementedError, self.browser.is_element_not_present_by_css, '.async-element', wait_time=3)
+
+    def test_is_element_present_by_xpath(self):
+        "should is element present by xpath verify if element is present"
+        self.assertTrue(self.browser.is_element_present_by_xpath('//h1'))
+
+    def test_is_element_present_by_xpath_using_a_custom_wait_time(self):
+        "should is element present by xpath raise NotImplementedError if using a custom wait time"
+        self.assertRaises(NotImplementedError, self.browser.is_element_present_by_xpath, '//h5', wait_time=3)
+
+    def test_is_element_present_by_xpath_returns_false_if_element_is_not_present(self):
+        "should is element present by xpath returns false if element is not present"
+        self.assertTrue(self.browser.is_element_not_present_by_xpath('//h4'))
+
+    def test_is_element_not_present_by_xpath_returns_false_if_element_is_present(self):
+        "should is element not present by xpath returns false if element is present"
+        self.assertFalse(self.browser.is_element_not_present_by_xpath('//h1'))
+
+    def test_is_element_not_present_by_xpath_using_a_custom_wait_time(self):
+        "should is element not present by xpath raise NotImplementedError if using a custom wait time"
+        self.assertRaises(NotImplementedError, self.browser.is_element_not_present_by_xpath, '//h4', wait_time=3)
+
+    def test_is_element_present_by_tag(self):
+        "should is element present by tag verify if element is present"
+        self.assertTrue(self.browser.is_element_present_by_tag('h1'))
+
+    def test_is_element_present_by_tag_using_a_custom_wait_time(self):
+        "should is element present by tag raise NotImplementedError if using a custom wait time"
+        self.assertRaises(NotImplementedError, self.browser.is_element_present_by_tag, 'h4', wait_time=3)
+
+    def test_is_element_present_by_tag_returns_false_if_element_is_not_present(self):
+        "should is element present by tag returns false if element is not present"
+        self.assertFalse(self.browser.is_element_present_by_tag('h4'))
+
+    def test_is_element_not_present_by_tag(self):
+        "should is element not present by tag verify if element is not present"
+        self.assertTrue(self.browser.is_element_not_present_by_tag('h4'))
+
+    def test_is_element_not_present_by_tag_using_a_custom_wait_time(self):
+        "should is element not present by tag raise NotImplementedError if using a custom wait time"
+        self.assertRaises(NotImplementedError, self.browser.is_element_not_present_by_tag, 'h4', wait_time=3)
+
+    def test_is_element_not_present_by_tag_returns_false_if_element_is_present(self):
+        "should is element not present by tag returns false if element is present"
+        self.assertFalse(self.browser.is_element_not_present_by_tag('h1'))
+
+    def test_is_element_present_by_text(self):
+        "should is element present by text verify if element is present"
+        self.assertTrue(self.browser.is_element_present_by_text('Complex'))
+
+    def test_is_element_present_by_text_returns_false_if_element_is_not_present(self):
+        "should is element present by text verify if element is present"
+        self.assertFalse(self.browser.is_element_present_by_text('Not present'))
+
+    def test_is_element_not_present_by_text(self):
+        "should is element not present by text verify if element is not present"
+        self.assertTrue(self.browser.is_element_not_present_by_text('Not present'))
+
+    def test_is_element_not_present_by_text_returns_false_if_element_is_present(self):
+        "should is element not present by text returns False if element is present"
+        self.assertFalse(self.browser.is_element_not_present_by_text('Complex'))
+
+    def test_is_element_present_by_value(self):
+        "should is element present by value verify if element is present"
+        self.assertTrue(self.browser.is_element_present_by_value('M'))
+
+    def test_is_element_present_by_value_using_a_custom_wait_time(self):
+        "should is element present by value raise NotImplementedError if a custom wait time"
+        self.assertRaises(NotImplementedError, self.browser.is_element_present_by_value, 'async-header-value', wait_time=3)
+
+    def test_is_element_present_by_value_returns_false_if_element_is_not_present(self):
+        "should is element present by value returns False if element is not present"
+        self.assertFalse(self.browser.is_element_present_by_value('async-header-value'))
+
+    def test_is_element_not_present_by_value(self):
+        "should is element not present by value verify if element is not present"
+        self.assertTrue(self.browser.is_element_not_present_by_value('async-header-value'))
+
+    def test_is_element_not_present_by_value_using_a_custom_wait_time(self):
+        "should is element not present by value raise NotImplementedError if using a custom wait time"
+        self.assertRaises(NotImplementedError, self.browser.is_element_not_present_by_value, 'async-header-value', wait_time=3)
+
+    def test_is_element_not_present_by_value_returns_false_if_element_is_present(self):
+        "should is element not present by value returns False if element is present"
+        self.assertFalse(self.browser.is_element_not_present_by_value('default value'))
+
+    def test_is_element_present_by_id(self):
+        "should is element present by id verify if element is present"
+        self.assertTrue(self.browser.is_element_present_by_id('firstheader'))
+
+    def test_is_element_present_by_id_using_a_custom_wait_time(self):
+        "should is element present by id raise NotImplementedError if using a custom wait time"
+        self.assertRaises(NotImplementedError, self.browser.is_element_present_by_id, 'async-header', wait_time=3)
+
+    def test_is_element_present_by_id_returns_false_if_element_is_not_present(self):
+        "should is element present by id returns False if element is not present"
+        self.assertFalse(self.browser.is_element_present_by_id('async-header'))
+
+    def test_is_element_not_present_by_id(self):
+        "should is element not present by id verify if element is not present"
+        self.assertTrue(self.browser.is_element_not_present_by_id('async-header'))
+
+    def test_is_element_not_present_by_id_using_a_custom_wait_time(self):
+        "should is element not present by id raise NotImplementedError if using a custom wait time"
+        self.assertRaises(NotImplementedError, self.browser.is_element_not_present_by_id, 'async-header', wait_time=3)
+
+    def test_is_element_not_present_by_id_returns_false_if_element_is_present(self):
+        "should is element not present by id returns False if element is present"
+        self.assertFalse(self.browser.is_element_not_present_by_id('firstheader'))
+
+    def test_is_element_present_by_name(self):
+        "should is element present by name verify if element is present"
+        self.assertTrue(self.browser.is_element_present_by_name('query'))
+
+    def test_is_element_present_by_name_using_a_custom_wait_time(self):
+        "should is element present by name raise NotImplementedError if using a custom wait time"
+        self.assertRaises(NotImplementedError, self.browser.is_element_present_by_name, 'async-input', wait_time=3)
+
+    def test_is_element_present_by_name_returns_false_if_element_is_not_present(self):
+        "should is element present by name returns false if element is not present"
+        self.assertFalse(self.browser.is_element_present_by_name('async-input'))
+
+    def test_is_element_not_present_by_name(self):
+        "should is element not present by name verify if element is not present"
+        self.assertTrue(self.browser.is_element_not_present_by_name('async-input'))
+
+    def test_is_element_not_present_by_name_using_a_custom_wait_time(self):
+        "should is element not present by name raise NotImplementedError if using a custom wait time"
+        self.assertRaises(NotImplementedError, self.browser.is_element_not_present_by_name, 'async-input', wait_time=3)
+
+    def test_is_element_not_present_by_name_returns_false_if_element_is_present(self):
+        "should is element not present by name returns false if element is present"
+        self.assertFalse(self.browser.is_element_not_present_by_name('query'))

--- a/tests/is_element_present_nojs.py
+++ b/tests/is_element_present_nojs.py
@@ -11,10 +11,6 @@ class IsElementPresentNoJSTest(object):
         "should is element present by css verify if element is present"
         self.assertTrue(self.browser.is_element_present_by_css('h1'))
 
-    def test_is_element_present_by_css_using_a_custom_wait_time(self):
-        "should is element present by css raise NotImplementedError if using a custom wait time"
-        self.assertRaises(NotImplementedError, self.browser.is_element_present_by_css, '.async-element2', wait_time=3)
-
     def test_is_element_present_by_css_returns_false_if_element_is_not_present(self):
         "should is element present by css returns False if element is not present"
         self.assertFalse(self.browser.is_element_present_by_css('.async-elementzz'))
@@ -27,17 +23,9 @@ class IsElementPresentNoJSTest(object):
         "should is element not present by css returns False if element is present"
         self.assertFalse(self.browser.is_element_not_present_by_css('h1'))
 
-    def test_is_element_not_present_by_css_using_a_custom_wait_time(self):
-        "should is element not present by css raise NotImplementedError if using a custom wait time"
-        self.assertRaises(NotImplementedError, self.browser.is_element_not_present_by_css, '.async-element', wait_time=3)
-
     def test_is_element_present_by_xpath(self):
         "should is element present by xpath verify if element is present"
         self.assertTrue(self.browser.is_element_present_by_xpath('//h1'))
-
-    def test_is_element_present_by_xpath_using_a_custom_wait_time(self):
-        "should is element present by xpath raise NotImplementedError if using a custom wait time"
-        self.assertRaises(NotImplementedError, self.browser.is_element_present_by_xpath, '//h5', wait_time=3)
 
     def test_is_element_present_by_xpath_returns_false_if_element_is_not_present(self):
         "should is element present by xpath returns false if element is not present"
@@ -47,17 +35,9 @@ class IsElementPresentNoJSTest(object):
         "should is element not present by xpath returns false if element is present"
         self.assertFalse(self.browser.is_element_not_present_by_xpath('//h1'))
 
-    def test_is_element_not_present_by_xpath_using_a_custom_wait_time(self):
-        "should is element not present by xpath raise NotImplementedError if using a custom wait time"
-        self.assertRaises(NotImplementedError, self.browser.is_element_not_present_by_xpath, '//h4', wait_time=3)
-
     def test_is_element_present_by_tag(self):
         "should is element present by tag verify if element is present"
         self.assertTrue(self.browser.is_element_present_by_tag('h1'))
-
-    def test_is_element_present_by_tag_using_a_custom_wait_time(self):
-        "should is element present by tag raise NotImplementedError if using a custom wait time"
-        self.assertRaises(NotImplementedError, self.browser.is_element_present_by_tag, 'h4', wait_time=3)
 
     def test_is_element_present_by_tag_returns_false_if_element_is_not_present(self):
         "should is element present by tag returns false if element is not present"
@@ -66,10 +46,6 @@ class IsElementPresentNoJSTest(object):
     def test_is_element_not_present_by_tag(self):
         "should is element not present by tag verify if element is not present"
         self.assertTrue(self.browser.is_element_not_present_by_tag('h4'))
-
-    def test_is_element_not_present_by_tag_using_a_custom_wait_time(self):
-        "should is element not present by tag raise NotImplementedError if using a custom wait time"
-        self.assertRaises(NotImplementedError, self.browser.is_element_not_present_by_tag, 'h4', wait_time=3)
 
     def test_is_element_not_present_by_tag_returns_false_if_element_is_present(self):
         "should is element not present by tag returns false if element is present"
@@ -95,10 +71,6 @@ class IsElementPresentNoJSTest(object):
         "should is element present by value verify if element is present"
         self.assertTrue(self.browser.is_element_present_by_value('M'))
 
-    def test_is_element_present_by_value_using_a_custom_wait_time(self):
-        "should is element present by value raise NotImplementedError if a custom wait time"
-        self.assertRaises(NotImplementedError, self.browser.is_element_present_by_value, 'async-header-value', wait_time=3)
-
     def test_is_element_present_by_value_returns_false_if_element_is_not_present(self):
         "should is element present by value returns False if element is not present"
         self.assertFalse(self.browser.is_element_present_by_value('async-header-value'))
@@ -106,10 +78,6 @@ class IsElementPresentNoJSTest(object):
     def test_is_element_not_present_by_value(self):
         "should is element not present by value verify if element is not present"
         self.assertTrue(self.browser.is_element_not_present_by_value('async-header-value'))
-
-    def test_is_element_not_present_by_value_using_a_custom_wait_time(self):
-        "should is element not present by value raise NotImplementedError if using a custom wait time"
-        self.assertRaises(NotImplementedError, self.browser.is_element_not_present_by_value, 'async-header-value', wait_time=3)
 
     def test_is_element_not_present_by_value_returns_false_if_element_is_present(self):
         "should is element not present by value returns False if element is present"
@@ -119,10 +87,6 @@ class IsElementPresentNoJSTest(object):
         "should is element present by id verify if element is present"
         self.assertTrue(self.browser.is_element_present_by_id('firstheader'))
 
-    def test_is_element_present_by_id_using_a_custom_wait_time(self):
-        "should is element present by id raise NotImplementedError if using a custom wait time"
-        self.assertRaises(NotImplementedError, self.browser.is_element_present_by_id, 'async-header', wait_time=3)
-
     def test_is_element_present_by_id_returns_false_if_element_is_not_present(self):
         "should is element present by id returns False if element is not present"
         self.assertFalse(self.browser.is_element_present_by_id('async-header'))
@@ -130,10 +94,6 @@ class IsElementPresentNoJSTest(object):
     def test_is_element_not_present_by_id(self):
         "should is element not present by id verify if element is not present"
         self.assertTrue(self.browser.is_element_not_present_by_id('async-header'))
-
-    def test_is_element_not_present_by_id_using_a_custom_wait_time(self):
-        "should is element not present by id raise NotImplementedError if using a custom wait time"
-        self.assertRaises(NotImplementedError, self.browser.is_element_not_present_by_id, 'async-header', wait_time=3)
 
     def test_is_element_not_present_by_id_returns_false_if_element_is_present(self):
         "should is element not present by id returns False if element is present"
@@ -143,10 +103,6 @@ class IsElementPresentNoJSTest(object):
         "should is element present by name verify if element is present"
         self.assertTrue(self.browser.is_element_present_by_name('query'))
 
-    def test_is_element_present_by_name_using_a_custom_wait_time(self):
-        "should is element present by name raise NotImplementedError if using a custom wait time"
-        self.assertRaises(NotImplementedError, self.browser.is_element_present_by_name, 'async-input', wait_time=3)
-
     def test_is_element_present_by_name_returns_false_if_element_is_not_present(self):
         "should is element present by name returns false if element is not present"
         self.assertFalse(self.browser.is_element_present_by_name('async-input'))
@@ -154,10 +110,6 @@ class IsElementPresentNoJSTest(object):
     def test_is_element_not_present_by_name(self):
         "should is element not present by name verify if element is not present"
         self.assertTrue(self.browser.is_element_not_present_by_name('async-input'))
-
-    def test_is_element_not_present_by_name_using_a_custom_wait_time(self):
-        "should is element not present by name raise NotImplementedError if using a custom wait time"
-        self.assertRaises(NotImplementedError, self.browser.is_element_not_present_by_name, 'async-input', wait_time=3)
 
     def test_is_element_not_present_by_name_returns_false_if_element_is_present(self):
         "should is element not present by name returns false if element is present"

--- a/tests/test_djangoclient.py
+++ b/tests/test_djangoclient.py
@@ -12,6 +12,7 @@ from six.moves.urllib import parse
 from splinter import Browser
 from .base import BaseBrowserTests
 from .fake_webapp import EXAMPLE_APP
+from .is_element_present_nojs import IsElementPresentNoJSTest
 
 
 sys.path.append('tests/fake_django')
@@ -23,7 +24,7 @@ import django
 django.setup()
 
 
-class DjangoClientDriverTest(BaseBrowserTests, unittest.TestCase):
+class DjangoClientDriverTest(BaseBrowserTests, IsElementPresentNoJSTest, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):

--- a/tests/test_flaskclient.py
+++ b/tests/test_flaskclient.py
@@ -10,9 +10,10 @@ import unittest
 from splinter import Browser
 from .base import BaseBrowserTests
 from .fake_webapp import app, EXAMPLE_APP
+from .is_element_present_nojs import IsElementPresentNoJSTest
 
 
-class FlaskClientDriverTest(BaseBrowserTests, unittest.TestCase):
+class FlaskClientDriverTest(BaseBrowserTests, IsElementPresentNoJSTest, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):

--- a/tests/test_zopetestbrowser.py
+++ b/tests/test_zopetestbrowser.py
@@ -11,11 +11,12 @@ import sys
 from splinter import Browser
 from .base import BaseBrowserTests
 from .fake_webapp import EXAMPLE_APP
+from .is_element_present_nojs import IsElementPresentNoJSTest
 
 
 @unittest.skipIf(sys.version_info[0] > 2,
                  'zope.testbrowser is not currently compatible with Python 3')
-class ZopeTestBrowserDriverTest(BaseBrowserTests, unittest.TestCase):
+class ZopeTestBrowserDriverTest(BaseBrowserTests, IsElementPresentNoJSTest, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
In order to bring more compatibility between javascript and non-javascript drivers I have implemented missing is_element_present_by_* methods. Although those methods are supposed to be used for dynamically appearing elements on page they are convenient also for static elements. I thing it is worth including them for non-javascript drivers. We have already is_text_present in non-javascript drivers.

Implemented methods will raise NotImplementedError if someone try to use wait_time, as it has not sense to use it in non-javascript drivers. I'm not really sure is it expected behavior. My thinking was that it is better to clearly communicate for user that it's not supported and make him catch error and do what he thing is suitable then force him to debug why it doesn't wait for loading.