### PR TITLE
Consistent redirects behaviour

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -86,6 +86,16 @@ class BaseBrowserTests(ElementTest, FindElementsTest, FormElementsTest, ClickEle
         element = self.browser.find_by_id("firstheader")
         self.assertEqual(self.browser, element.parent)
 
+    def test_redirection(self):
+        """
+        when visiting /redirected, browser should be redirected to /redirected-location?come=get&some=true
+        browser.url should be updated
+        """
+        self.browser.visit('{}redirected'.format(EXAMPLE_APP))
+        self.assertIn('I just been redirected to this location.', self.browser.html)
+        self.assertIn('redirect-location?come=get&some=true', self.browser.url)
+        self.assertEqual(self.browser.status_code.code, 200)
+
 
 class WebDriverTests(BaseBrowserTests, IFrameElementsTest, ElementDoestNotExistTest, IsElementPresentTest,
                      IsElementVisibleTest, AsyncFinderTests, StatusCodeTest, MouseInteractionTest,

--- a/tests/base.py
+++ b/tests/base.py
@@ -94,7 +94,6 @@ class BaseBrowserTests(ElementTest, FindElementsTest, FormElementsTest, ClickEle
         self.browser.visit('{}redirected'.format(EXAMPLE_APP))
         self.assertIn('I just been redirected to this location.', self.browser.html)
         self.assertIn('redirect-location?come=get&some=true', self.browser.url)
-        self.assertEqual(self.browser.status_code.code, 200)
 
 
 class WebDriverTests(BaseBrowserTests, IFrameElementsTest, ElementDoestNotExistTest, IsElementPresentTest,

--- a/tests/fake_webapp.py
+++ b/tests/fake_webapp.py
@@ -4,7 +4,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from flask import Flask, request, abort, Response
+from flask import Flask, request, abort, Response, redirect, url_for
 from os import path
 from functools import wraps
 
@@ -128,6 +128,17 @@ def popup():
 @requires_auth
 def auth_required():
     return "Success!"
+
+
+@app.route('/redirected')
+def redirected():
+    location = '{}?{}'.format(url_for('redirect_location'), 'come=get&some=true')
+    return redirect(location)
+
+
+@app.route('/redirect-location')
+def redirect_location():
+    return EXAMPLE_REDIRECT_LOCATION_HTML
 
 
 def start_flask_app(host, port):

--- a/tests/test_djangoclient.py
+++ b/tests/test_djangoclient.py
@@ -135,15 +135,6 @@ class DjangoClientDriverTest(BaseBrowserTests, IsElementPresentNoJSTest, unittes
             link = self.browser.find_link_by_text(text)
             self.assertEqual(key, link['id'])
 
-    def test_redirection(self):
-        """
-        when visiting /redirected, browser should be redirected to /redirected-location?come=get&some=true
-        browser.url should be updated
-        """
-        self.browser.visit('{}redirected'.format(EXAMPLE_APP))
-        self.assertIn('I just been redirected to this location.', self.browser.html)
-        self.assertIn('redirect-location?come=get&some=true', self.browser.url)
-
 
 class DjangoClientDriverTestWithCustomHeaders(unittest.TestCase):
 


### PR DESCRIPTION
I have moved redirection test to base as it should work exactly the same in all drivers.
For flask, redirection have to be done in driver because flask doesn't expose redirection chain yet. It can be dropped (and probably integrated with django driver) once flask will expose it.