### PR TITLE
Webdriver support for clearing text field types

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -518,6 +518,10 @@ class WebDriverElement(ElementAPI):
     def tag_name(self):
         return self._element.tag_name
 
+    def clear(self):
+        if self._element.get_attribute('type') in ['textarea', 'text', 'password', 'tel']:
+            self._element.clear()
+
     def fill(self, value):
         self.value = value
 

--- a/tests/form_elements.py
+++ b/tests/form_elements.py
@@ -137,3 +137,30 @@ class FormElementsTest(object):
         self.browser.fill_form({'search_keyword': new_search_keyword})
         value = self.browser.find_by_name('search_keyword').value
         self.assertEqual(new_search_keyword, value)
+
+    def test_can_clear_text_field_content(self):
+        self.browser.fill('query', 'random query')
+        value = self.browser.find_by_name('query').value
+        self.assertEqual('random query', value)
+
+        self.browser.find_by_name('query').clear()
+        value = self.browser.find_by_name('query').value
+        self.assertNone(value)
+
+    def test_can_clear_password_field_content(self):
+        self.browser.fill('password', '1nF4m310')
+        value = self.browser.find_by_name('password').value
+        self.assertEqual('1nF4m310', value)
+
+        self.browser.find_by_name('password').clear()
+        value = self.browser.find_by_name('password').value
+        self.assertNone(value)
+
+    def test_can_clear_tel_field_content(self):
+        self.browser.fill('telephone', '5553743980')
+        value = self.browser.find_by_name('telephone').value
+        self.assertEqual('5553743980', value)
+
+        self.browser.find_by_name('telephone').clear()
+        value = self.browser.find_by_name('telephone').value
+        self.assertNone(value)


### PR DESCRIPTION
Clears text field types if they already have values in them

`browser.find_by_name('telephone').clear()`
`browser.find_by_tag('textarea').clear()`
`browser.find_by_id('username').clear()`