### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,24 +8,24 @@ splinter - python tool for test web applications
 
 splinter is a tool for test web applications with a simple for find elements, form actions, and others browser actions.
 
-`what's new in splinter? <http://splinter.readthedocs.org/en/latest/news.html>`_
+`what's new in splinter? <https://splinter.readthedocs.io/en/latest/news.html>`_
 
 first steps
 ===========
 
-* `Installation <http://splinter.readthedocs.org/en/latest/install.html>`_
-* `Quick tutorial <http://splinter.readthedocs.org/en/latest/tutorial.html>`_
+* `Installation <https://splinter.readthedocs.io/en/latest/install.html>`_
+* `Quick tutorial <https://splinter.readthedocs.io/en/latest/tutorial.html>`_
 
 splinter open source project
 ============================
 
-* `Community <http://splinter.readthedocs.org/en/latest/community.html>`_
-* `Contribute <http://splinter.readthedocs.org/en/latest/contribute.html>`_
+* `Community <https://splinter.readthedocs.io/en/latest/community.html>`_
+* `Contribute <https://splinter.readthedocs.io/en/latest/contribute.html>`_
 
 documentation
 =============
 
-`splinter documentation <http://splinter.readthedocs.org>`_
+`splinter documentation <https://splinter.readthedocs.io>`_
 
 external links
 ==============

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -49,7 +49,7 @@
 <div id="header">
     <div class="header-container">
         <div class="title">
-            <h1><a href="http://splinter.readthedocs.org/" title="splinter">splinter</a></h1>
+            <h1><a href="https://splinter.readthedocs.io/" title="splinter">splinter</a></h1>
             <p>test framework for web applications</p>
         </div>
         <ul class="nav">

--- a/docs/browser.rst
+++ b/docs/browser.rst
@@ -113,7 +113,7 @@ You can back and forward on your browsing history using ``back`` and ``forward``
 ::
 
     browser.visit('http://cobrateam.info')
-    browser.visit('http://splinter.readthedocs.org')
+    browser.visit('https://splinter.readthedocs.io')
     browser.back()
     browser.forward()
 

--- a/docs/drivers/remote.rst
+++ b/docs/drivers/remote.rst
@@ -55,7 +55,7 @@ browser instance running on Windows 7.
                  name="Test of IE 9 on WINDOWS") as browser:
         print("Link to job: https://saucelabs.com/jobs/{}".format(
               browser.driver.session_id))
-        browser.visit("http://splinter.readthedocs.org")
+        browser.visit("https://splinter.readthedocs.io")
         browser.find_link_by_text('documentation').first.click()
 
 

--- a/docs/matchers.rst
+++ b/docs/matchers.rst
@@ -34,7 +34,7 @@ in the page content. It returns ``True`` or ``False``.
 ::
 
     browser = Browser()
-    browser.visit('http://splinter.readthedocs.org/')
+    browser.visit('https://splinter.readthedocs.io/')
     browser.is_text_present('splinter') # True
     browser.is_text_present('splinter', wait_time=10) # True, using wait_time
     browser.is_text_present('text not present') # False

--- a/splinter/driver/__init__.py
+++ b/splinter/driver/__init__.py
@@ -503,7 +503,7 @@ class ElementAPI(InheritedDocs('_ElementAPI', (object,), {})):
     Once you have an instance, you can easily access attributes like a ``dict``:
 
         >>> element = browser.find_by_id("link-logo").first
-        >>> assert element['href'] == 'http://splinter.readthedocs.org'
+        >>> assert element['href'] == 'https://splinter.readthedocs.io'
 
     You can also interact with the instance using the methods and properties listed below.
     """


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.