### PR TITLE
allow to pass a chrome Options instance to Browser

### DIFF
--- a/docs/drivers/chrome.rst
+++ b/docs/drivers/chrome.rst
@@ -126,6 +126,29 @@ the ``Browser`` instance:
 
 **Note:** if you have trouble with ``$HOME/.bash_profile``, you can try ``$HOME/.bashrc``.
 
+Using emulation mode in Chrome
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Chrome options can be passed to customize Chrome's behaviour; it is then possible to leverage the
+experimental emulation mode.
+
+.. highlight:: python
+
+::
+
+    from selenium import webdriver
+    from splinter import Browser
+
+    mobile_emulation = {"deviceName": "Google Nexus 5"}
+    chrome_options = webdriver.ChromeOptions()
+    chrome_options.add_experimental_option("mobileEmulation",
+                                           mobile_emulation)
+    browser = Browser('chrome', options=chrome_options)
+
+
+refer to `chrome driver documentation <https://sites.google.com/a/chromium.org/chromedriver/mobile-emulation>`_
+
+
 API docs
 --------
 

--- a/splinter/driver/webdriver/chrome.py
+++ b/splinter/driver/webdriver/chrome.py
@@ -14,10 +14,10 @@ class WebDriver(BaseWebDriver):
 
     driver_name = "Chrome"
 
-    def __init__(self, user_agent=None, wait_time=2, fullscreen=False, incognito=False,
+    def __init__(self, options=None, user_agent=None, wait_time=2, fullscreen=False, incognito=False,
                  **kwargs):
 
-        options = Options()
+        options = Options() if options is None else options
 
         if user_agent is not None:
             options.add_argument("--user-agent=" + user_agent)


### PR DESCRIPTION
My use case was to enable the device emulation mode in Chrome.
Not much of a technical change, some more doc.