### PR TITLE
Don't hold a screenshot file opened

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -8,6 +8,7 @@ import tempfile
 import time
 import re
 import sys
+import os
 from contextlib import contextmanager
 
 from selenium.common.exceptions import NoSuchElementException
@@ -459,6 +460,8 @@ class BaseWebDriver(DriverAPI):
         name = name or ''
 
         (fd, filename) = tempfile.mkstemp(prefix=name, suffix=suffix)
+        # don't hold the file
+        os.close(fd)
 
         self.driver.get_screenshot_as_file(filename)
         return filename


### PR DESCRIPTION
Currently every taken screenshot file stays opened until python process is closed, which prevents removing it (on Windows)