### PR TITLE
Element screenshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 # license that can be found in the LICENSE file.
 
 sudo: required
+dist: trusty
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ] + [('Programming Language :: Python :: %s' % x) for x in '2.6 2.7 3.3 3.4'.split()],
     packages=find_packages(exclude=['docs', 'tests', 'samples']),
     include_package_data=True,
-    install_requires=['selenium>=2.53.6'],
+    install_requires=['selenium>=2.53.6', 'pillow'],
     extras_require={'zope.testbrowser': ['zope.testbrowser>=4.0.4',
                                          'lxml>=2.3.6', 'cssselect'],
                     'django': ['Django>=1.7.11,<1.10', 'lxml>=2.3.6', 'cssselect', 'six'],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,3 +8,4 @@ argparse
 Django>=1.7.11,<1.10
 flake8==2.5.4
 six==1.10.0
+pillow

--- a/tests/screenshot.py
+++ b/tests/screenshot.py
@@ -23,3 +23,21 @@ class ScreenshotTest(object):
         "should add the suffix to the screenshot file name"
         filename = self.browser.screenshot(suffix='jpeg')
         self.assertEqual('jpeg', filename[-4:])
+
+    def test_take_element_screenshot(self):
+        "should take a screenchot of the given element on the current page"
+        header = self.browser.find_by_id('firstheader')
+        filename = header.screenshot()
+        self.assertTrue(tempfile.gettempdir() in filename)
+
+    def test_take_element_screenshot_with_prefix(self):
+        "should take a screenchot of the given element on the current page"
+        header = self.browser.find_by_id('firstheader')
+        filename = header.screenshot(name='foobar')
+        self.assertTrue('foobar' in filename)
+
+    def test_take_element_screenshot_with_suffix(self):
+        "should take a screenchot of the given element on the current page"
+        header = self.browser.find_by_id('firstheader')
+        filename = header.screenshot(suffix='.jpeg')
+        self.assertEqual('.jpeg', filename[-5:])

--- a/travis-install.bash
+++ b/travis-install.bash
@@ -25,12 +25,13 @@ if [ "${DRIVER}" = "tests/test_webdriver_firefox.py" ]; then
     bzip2 -dc firefox.tbz2 | tar xvf -
     mv ./firefox $HOME
     export PATH=$HOME/firefox:$PATH
+    echo "Firefox version: $(firefox -v)"
 fi
 
 if [ "${DRIVER}" = "tests/test_webdriver_chrome.py" ]; then
     sleep 1
 
-    FILE=`mktemp`; wget "http://chromedriver.storage.googleapis.com/2.20/chromedriver_linux64.zip" -qO $FILE && unzip $FILE chromedriver -d ~; rm $FILE; chmod 777 ~/chromedriver;
+    FILE=`mktemp`; wget "http://chromedriver.storage.googleapis.com/2.24/chromedriver_linux64.zip" -qO $FILE && unzip $FILE chromedriver -d ~; rm $FILE; chmod 777 ~/chromedriver;
     export PATH=$HOME:$PATH
 fi
 

--- a/travis-install.bash
+++ b/travis-install.bash
@@ -33,3 +33,12 @@ if [ "${DRIVER}" = "tests/test_webdriver_chrome.py" ]; then
     FILE=`mktemp`; wget "http://chromedriver.storage.googleapis.com/2.20/chromedriver_linux64.zip" -qO $FILE && unzip $FILE chromedriver -d ~; rm $FILE; chmod 777 ~/chromedriver;
     export PATH=$HOME:$PATH
 fi
+
+if [ "${DRIVER}" = "tests/test_webdriver_phantomjs.py" ]; then
+    sleep 1
+
+    FILENAME="phantomjs-2.1.1-linux-x86_64"
+    wget "https://bitbucket.org/ariya/phantomjs/downloads/${FILENAME}.tar.bz2" -q && tar -C ~ --strip-components 2 -jvxf ${FILENAME}.tar.bz2 ${FILENAME}/bin/phantomjs
+    export PATH=$HOME:$PATH
+    echo "PhantomJs version: $(phantomjs -v)"
+fi


### PR DESCRIPTION
This adds `screenshot` method to `WebDriverElement` class. Depends on [`pillow`](https://pypi.python.org/pypi/Pillow/3.3.0).
Fixes #500 and supersedes #384.
I also updated `phantomjs` to `2.1.1` on travis since old version hangs.
