### PR TITLE
zopebrowser: don't find_by_name if there ain't no name

### DIFF
--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -138,7 +138,7 @@ class ZopeTestBrowser(ElementPresentMixIn, DriverAPI):
         for xpath_element in html.xpath(xpath):
             if self._element_is_link(xpath_element):
                 return self._find_links_by_xpath(xpath)
-            elif self._element_is_control(xpath_element):
+            elif self._element_is_control(xpath_element) and xpath_element.name:
                 return self.find_by_name(xpath_element.name)
             else:
                 elements.append(xpath_element)


### PR DESCRIPTION
Ref: #125 

ZopeTestBrowser.find_by_xpath now checks if xpath_element has a name before passing it to ZopeTestBrowser.find_by_name.

Later: can probably maybe add logic to check for labels, since zope.testbrowser.browser.getControl accepts a name or a label.
