### PR TITLE
update the way chrome options are passed (issue #511)

### DIFF
--- a/splinter/driver/webdriver/chrome.py
+++ b/splinter/driver/webdriver/chrome.py
@@ -17,18 +17,22 @@ class WebDriver(BaseWebDriver):
     def __init__(self, options=None, user_agent=None, wait_time=2, fullscreen=False, incognito=False,
                  **kwargs):
 
-        options = Options() if options is None else options
+        pass_options = Options() 
+
+        if options is not None:
+            for option in options:
+                pass_options.add_argument(option)
 
         if user_agent is not None:
-            options.add_argument("--user-agent=" + user_agent)
+            pass_options.add_argument("--user-agent=" + user_agent)
             
-        if incognito is not None:
-            options.add_argument("--incognito")
+        if incognito:
+            pass_options.add_argument("--incognito")
 
         if fullscreen:
-            options.add_argument('--kiosk')
+            pass_options.add_argument('--kiosk')
 
-        self.driver = Chrome(chrome_options=options, **kwargs)
+        self.driver = Chrome(chrome_options=pass_options, **kwargs)
 
         self.element_class = WebDriverElement
 


### PR DESCRIPTION
Allows the [various chrome options](http://peter.sh/experiments/chromium-command-line-switches/) to be passed in as a list

```
from splinter import Browser

options = ['--lang=en-us', '--start-fullscreen']

with Browser('chrome', options=options) as browser:
    browser.visit('http://example.com')
    browser.quit()
```
