### PR TITLE
consider a <textarea> a control element

### DIFF
--- a/splinter/driver/lxmldriver.py
+++ b/splinter/driver/lxmldriver.py
@@ -266,7 +266,7 @@ class LxmlDriver(ElementPresentMixIn, DriverAPI):
         return element.tag == 'a'
 
     def _element_is_control(self, element):
-        return hasattr(element, 'type')
+        return hasattr(element, 'type') or element.tag == 'textarea'
 
     @property
     def cookies(self):

--- a/splinter/driver/lxmldriver.py
+++ b/splinter/driver/lxmldriver.py
@@ -266,7 +266,7 @@ class LxmlDriver(ElementPresentMixIn, DriverAPI):
         return element.tag == 'a'
 
     def _element_is_control(self, element):
-        return hasattr(element, 'type') or element.tag in ['button', 'input', 'textarea']
+        return element.tag in ['button', 'input', 'textarea']
 
     @property
     def cookies(self):

--- a/splinter/driver/lxmldriver.py
+++ b/splinter/driver/lxmldriver.py
@@ -266,7 +266,7 @@ class LxmlDriver(ElementPresentMixIn, DriverAPI):
         return element.tag == 'a'
 
     def _element_is_control(self, element):
-        return hasattr(element, 'type') or element.tag == 'textarea'
+        return hasattr(element, 'type') or element.tag == 'button' or element.tag == 'textarea'
 
     @property
     def cookies(self):

--- a/splinter/driver/lxmldriver.py
+++ b/splinter/driver/lxmldriver.py
@@ -266,7 +266,7 @@ class LxmlDriver(ElementPresentMixIn, DriverAPI):
         return element.tag == 'a'
 
     def _element_is_control(self, element):
-        return hasattr(element, 'type') or element.tag == 'button' or element.tag == 'textarea'
+        return hasattr(element, 'type') or element.tag in ['button', 'input', 'textarea']
 
     @property
     def cookies(self):

--- a/tests/form_elements.py
+++ b/tests/form_elements.py
@@ -31,6 +31,11 @@ class FormElementsTest(object):
         self.browser.choose("gender", "M")
         self.assertTrue(self.browser.find_by_id("gender-m").checked)
 
+    def test_can_find_textarea_by_tag(self):
+        "should provide a way to find a textarea by tag_name"
+        tag = self.browser.find_by_tag("textarea").first
+        self.assertEqual('', tag.value)
+
     def test_can_find_option_by_value(self):
         "should provide a way to find select option by value"
         self.assertEqual("Rio de Janeiro", self.browser.find_option_by_value("rj").text)

--- a/tests/form_elements.py
+++ b/tests/form_elements.py
@@ -36,6 +36,16 @@ class FormElementsTest(object):
         tag = self.browser.find_by_tag("textarea").first
         self.assertEqual('', tag.value)
 
+    def test_can_find_input_without_type(self):
+        "should recognize an input element that doesn't have a `type` attribute"
+        tag = self.browser.find_by_css('[name="typeless"]').first
+        self.assertEqual('default value', tag.value)
+
+    def test_can_find_button(self):
+        "should recognize a button"
+        tag = self.browser.find_by_css('.just-a-button').first
+        self.assertTrue(hasattr(tag, 'click'))
+
     def test_can_find_option_by_value(self):
         "should provide a way to find select option by value"
         self.assertEqual("Rio de Janeiro", self.browser.find_option_by_value("rj").text)

--- a/tests/static/index.html
+++ b/tests/static/index.html
@@ -86,6 +86,7 @@
         <input type="text" name="input1" value="default value" />
         <input type="text" name="input1" value="default last value" />
         <input type="text" name="query" value="default value" />
+        <input name="typeless" value="default value" />
         <input type="password" name="password" />
         <input type="tel" name="telephone" />
         <input type="search" name="search_keyword" />
@@ -143,6 +144,7 @@
     <a class="add-async-element" href="#">add async element</a>
     <a class="remove-async-element" href="#">remove async element</a>
     <a class="add-element-mouseover" href="#">addelement (mouseover)</a>
+    <button class="just-a-button"></button>
     <iframe id="iframemodal" src="/iframe"></iframe>
     <div id="inside">
         <h2>inside</h2>


### PR DESCRIPTION
Previously, `find_by_xpath()` (or `find_by_tag()`, etc.) would not consider a `<textarea>` a "control element", and would return it as an `LxmlElement`, which can't be `fill()`d. This (should) make it so that all `find_by_*` methods treat `<textarea>`s the same.