### PR TITLE
Take in **kwargs for Firefox to pass them on to Selenium

### DIFF
--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -19,7 +19,7 @@ class WebDriver(BaseWebDriver):
 
     def __init__(self, profile=None, extensions=None, user_agent=None,
                  profile_preferences=None, fullscreen=False, wait_time=2,
-                 timeout=90, capabilities=None):
+                 timeout=90, capabilities=None, **kwargs):
 
         firefox_profile = FirefoxProfile(profile)
         firefox_profile.set_preference('extensions.logging.enabled', False)
@@ -46,7 +46,7 @@ class WebDriver(BaseWebDriver):
 
         self.driver = Firefox(firefox_profile,
                               capabilities=firefox_capabilities,
-                              timeout=timeout)
+                              timeout=timeout, **kwargs)
 
         if fullscreen:
             ActionChains(self.driver).send_keys(Keys.F11).perform()


### PR DESCRIPTION
To be able to specify `firefox_binary` and `executable_path`.

See https://github.com/SeleniumHQ/selenium/blob/b94c9021aa40c12494cd3f88f7c2220af79f8b41/py/selenium/webdriver/firefox/webdriver.py#L55 from the Selenium 3.1.0 release commit.