### PR TITLE
Document behavior of `slowly=True` in `type()`

### DIFF
--- a/splinter/driver/__init__.py
+++ b/splinter/driver/__init__.py
@@ -233,6 +233,8 @@ class DriverAPI(InheritedDocs('_DriverAPI', (object,), {})):
         Types the ``value`` in the field identified by ``name``.
 
         It's useful to test javascript events like keyPress, keyUp, keyDown, etc.
+        
+        If ``slowly`` is True, this function returns an iterator which will type one character per iteration.
         """
         raise NotImplementedError("%s doesn't support typing on fields by name." % self.driver_name)
 
@@ -610,6 +612,8 @@ class ElementAPI(InheritedDocs('_ElementAPI', (object,), {})):
         Types the ``value`` in the field.
 
         It's useful to test javascript events like keyPress, keyUp, keyDown, etc.
+        
+        If ``slowly`` is True, this function returns an iterator which will type one character per iteration.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
I was surprised to find that passing `slowly=True` changes the function's behavior so that it doesn't perform the action directly, but instead returns an iterator. Hopefully this will help keep others from being surprised.