### PR TITLE
Headless option for chrome

### DIFF
--- a/docs/drivers/chrome.rst
+++ b/docs/drivers/chrome.rst
@@ -126,8 +126,21 @@ the ``Browser`` instance:
 
 **Note:** if you have trouble with ``$HOME/.bash_profile``, you can try ``$HOME/.bashrc``.
 
+Using headless option for Chrome
+--------------------------------
+
+Starting with Chrome 59, we can run Chrome as a headless browser.
+Make sure you read `google developers updates <https://developers.google.com/web/updates/2017/05/nic59#headless>`_
+
+.. highlight:: python
+
+::
+
+    from splinter import Browser
+    browser = Browser('chrome', headless=True)
+
 Using emulation mode in Chrome
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 Chrome options can be passed to customize Chrome's behaviour; it is then possible to leverage the
 experimental emulation mode.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,6 +95,7 @@ Headless drivers
 The following drivers don't open a browser to run your actions (but has its own dependencies, check the
 specific docs for each driver):
 
+* :doc:`Chrome WebDriver </drivers/chrome>`
 * :doc:`Phantomjs WebDriver </drivers/phantomjs>`
 * :doc:`zope.testbrowser </drivers/zope.testbrowser>`
 * :doc:`django client </drivers/django>`

--- a/splinter/driver/webdriver/chrome.py
+++ b/splinter/driver/webdriver/chrome.py
@@ -14,8 +14,8 @@ class WebDriver(BaseWebDriver):
 
     driver_name = "Chrome"
 
-    def __init__(self, options=None, user_agent=None, wait_time=2, fullscreen=False, incognito=False,
-                 **kwargs):
+    def __init__(self, options=None, user_agent=None, wait_time=2,
+                 fullscreen=False, incognito=False, headless=False, **kwargs):
 
         options = Options() if options is None else options
 
@@ -27,6 +27,9 @@ class WebDriver(BaseWebDriver):
 
         if fullscreen:
             options.add_argument('--kiosk')
+
+        if headless:
+            options.add_argument('--headless')
 
         self.driver = Chrome(chrome_options=options, **kwargs)
 


### PR DESCRIPTION
Starting with Chrome 59, Google has implemented a headless option. 
As you all know, PhantomJS will no longer be supported as the project lead stepped down.

More infos here:
https://developers.google.com/web/updates/2017/04/headless-chrome

Regards,
Dan