### PR TITLE
Add example remote URL for Saucelabs

### DIFF
--- a/docs/drivers/remote.rst
+++ b/docs/drivers/remote.rst
@@ -44,8 +44,8 @@ browser instance running on Windows 7.
 .. highlight:: python
 
 ::
-
-    remote_server_url = ... # Specify the server URL
+    # Specify the server URL
+    remote_server_url = 'http://YOUR_SAUCE_USERNAME:YOUR_SAUCE_ACCESS_KEY@ondemand.saucelabs.com:80/wd/hub'
 
     with Browser(driver_name="remote",
                  url=remote_server_url,

--- a/docs/drivers/remote.rst
+++ b/docs/drivers/remote.rst
@@ -44,6 +44,7 @@ browser instance running on Windows 7.
 .. highlight:: python
 
 ::
+
     # Specify the server URL
     remote_server_url = 'http://YOUR_SAUCE_USERNAME:YOUR_SAUCE_ACCESS_KEY@ondemand.saucelabs.com:80/wd/hub'
 


### PR DESCRIPTION
I ran into not knowing exactly what the URL should be. After checking the Saucelabs docs I found out, might be handy to just have it in here.