### PR TITLE
Make `fill_form` more robust by requiring form ID.

### DIFF
--- a/splinter/driver/__init__.py
+++ b/splinter/driver/__init__.py
@@ -244,7 +244,7 @@ class DriverAPI(InheritedDocs('_DriverAPI', (object,), {})):
         """
         raise NotImplementedError("%s doesn't support filling fields by name." % self.driver_name)
 
-    def fill_form(self, field_values):
+    def fill_form(self, field_values, form_id=None, name=None):
         """
         Fill the fields identified by ``name`` with the content specified by ``value`` in a dict.
 

--- a/splinter/driver/lxmldriver.py
+++ b/splinter/driver/lxmldriver.py
@@ -200,9 +200,21 @@ class LxmlDriver(ElementPresentMixIn, DriverAPI):
     def fill(self, name, value):
         self.find_by_name(name=name).first.fill(value)
 
-    def fill_form(self, field_values):
+    def fill_form(self, field_values, form_id=None, name=None):
+        form = None
+
+        if name is not None:
+            form = self.find_by_name(name)
+        if form_id is not None:
+            form = self.find_by_xpath(
+                '//form[contains(@id, "{0}")]'.format(form_id))
+
         for name, value in field_values.items():
-            element = self.find_by_name(name)
+            if form:
+                elements = form.find_by_name(name)
+            else:
+                elements = self.find_by_name(name)
+            element = elements.first
             control = element.first._control
             control_type = control.get('type')
             if control_type == 'checkbox':

--- a/splinter/driver/lxmldriver.py
+++ b/splinter/driver/lxmldriver.py
@@ -206,15 +206,15 @@ class LxmlDriver(ElementPresentMixIn, DriverAPI):
         if name is not None:
             form = self.find_by_name(name)
         if form_id is not None:
-            form = self.find_by_xpath(
-                '//form[contains(@id, "{0}")]'.format(form_id))
+            form = self.find_by_id(form_id)
 
         for name, value in field_values.items():
             if form:
                 element = form.find_by_name(name)
+                control = element.first._element
             else:
                 element = self.find_by_name(name)
-            control = element.first._control
+                control = element.first._control
             control_type = control.get('type')
             if control_type == 'checkbox':
                 if value:

--- a/splinter/driver/lxmldriver.py
+++ b/splinter/driver/lxmldriver.py
@@ -211,10 +211,9 @@ class LxmlDriver(ElementPresentMixIn, DriverAPI):
 
         for name, value in field_values.items():
             if form:
-                elements = form.find_by_name(name)
+                element = form.find_by_name(name)
             else:
-                elements = self.find_by_name(name)
-            element = elements.first
+                element = self.find_by_name(name)
             control = element.first._control
             control_type = control.get('type')
             if control_type == 'checkbox':

--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -417,11 +417,25 @@ class BaseWebDriver(DriverAPI):
 
     attach_file = fill
 
-    def fill_form(self, field_values):
+    def fill_form(self, field_values, form_id=None, name=None):
+        form = None
+
+        if name is not None:
+            form = self.find_by_name(name)
+        if form_id is not None:
+            form = self.find_by_xpath(
+                '//form[contains(@id, "{0}")]'.format(form_id))
+
         for name, value in field_values.items():
-            elements = self.find_by_name(name)
+            if form:
+                elements = form.find_by_name(name)
+            else:
+                elements = self.find_by_name(name)
             element = elements.first
-            if element['type'] in ['text', 'password', 'tel'] or element.tag_name == 'textarea':
+            if (
+                    element['type'] in ['text', 'password', 'tel'] or
+                    element.tag_name == 'textarea'
+            ):
                 element.value = value
             elif element['type'] == 'checkbox':
                 if value:

--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -423,8 +423,7 @@ class BaseWebDriver(DriverAPI):
         if name is not None:
             form = self.find_by_name(name)
         if form_id is not None:
-            form = self.find_by_xpath(
-                '//form[contains(@id, "{0}")]'.format(form_id))
+            form = self.find_by_id(form_id)
 
         for name, value in field_values.items():
             if form:

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -193,9 +193,21 @@ class ZopeTestBrowser(ElementPresentMixIn, DriverAPI):
     def fill(self, name, value):
         self.find_by_name(name=name).first._control.value = value
 
-    def fill_form(self, field_values):
+    def fill_form(self, field_values, form_id=None, name=None):
+        form = None
+
+        if name is not None:
+            form = self.find_by_name(name)
+        if form_id is not None:
+            form = self.find_by_xpath(
+                '//form[contains(@id, "{0}")]'.format(form_id))
+
         for name, value in field_values.items():
-            element = self.find_by_name(name)
+            if form:
+                elements = form.find_by_name(name)
+            else:
+                elements = self.find_by_name(name)
+            element = elements.first
             control = element.first._control
             if control.type == 'checkbox':
                 if value:

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -199,16 +199,15 @@ class ZopeTestBrowser(ElementPresentMixIn, DriverAPI):
         if name is not None:
             form = self.find_by_name(name)
         if form_id is not None:
-            form = self.find_by_xpath(
-                '//form[contains(@id, "{0}")]'.format(form_id))
+            form = self.find_by_id(form_id)
 
         for name, value in field_values.items():
             if form:
-                elements = form.find_by_name(name)
+                element = form.find_by_name(name)
+                control = element.first._element
             else:
-                elements = self.find_by_name(name)
-            element = elements.first
-            control = element.first._control
+                element = self.find_by_name(name)
+                control = element.first._control
             if control.type == 'checkbox':
                 if value:
                     control.value = control.options

--- a/tests/form_elements.py
+++ b/tests/form_elements.py
@@ -199,6 +199,18 @@ class FormElementsTest(object):
         value = self.browser.find_by_name('search_keyword').value
         self.assertEqual(new_search_keyword, value)
 
+    def test_can_fill_form_by_id(self):
+        "should be able to fill a form by its id"
+        self.browser.fill_form(
+            {
+                'firstname': 'John',
+                'lastname': 'Doe',
+            },
+            form_id='login'
+        )
+        value = self.browser.find_by_name('firstname').value
+        self.assertEqual('John', value)
+
     def test_can_clear_text_field_content(self):
         self.browser.fill('query', 'random query')
         value = self.browser.find_by_name('query').value

--- a/tests/static/index.html
+++ b/tests/static/index.html
@@ -134,6 +134,15 @@
       <input type="submit" class="submit-input-no-name" value="submit-input-value"/>
     </form>
 
+ 
+    <form id='login'>
+      First name:<br>
+      <input type="text" name="firstname"><br>
+      Last name:<br>
+      <input type="text" name="lastname">
+    </form>
+ 
+    
     <a href="http://example.com/">Link for Example.com</a>
     <a href="http://example.com/last">Link for Example.com</a>
     <a href="http://example.com/">Link for last Example.com</a>


### PR DESCRIPTION
Current implementation for `fill_form` attempts to find fields by their names.
However, if the same name is found in multiple places, this method will either
fail with a `InvalidElementStateException` exception or the wrong field may be
filled.

Please see #564 for more info.