### PR TITLE
Allow return value for execute_script to be returned. Fixes #584.

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -195,7 +195,7 @@ class BaseWebDriver(DriverAPI):
         self.driver.refresh()
 
     def execute_script(self, script):
-        self.driver.execute_script(script)
+        return self.driver.execute_script(script)
 
     def evaluate_script(self, script):
         return self.driver.execute_script("return %s" % script)

--- a/tests/base.py
+++ b/tests/base.py
@@ -211,3 +211,6 @@ class WebDriverTests(BaseBrowserTests, IFrameElementsTest, ElementDoestNotExistT
         result = 'iphone' in browser.html
         browser.quit()
         self.assertTrue(result)
+
+    def test_execute_script_returns_result_if_present(self):
+        assert self.browser.execute_script('return 42') == 42


### PR DESCRIPTION
As described in #584, webdriver.execute_script should relay any return value from the underlying `driver.execute_script` call.