### PR TITLE
Pass 'options' instead of 'chrome_options'

### DIFF
--- a/splinter/driver/webdriver/chrome.py
+++ b/splinter/driver/webdriver/chrome.py
@@ -32,7 +32,7 @@ class WebDriver(BaseWebDriver):
             options.add_argument('--headless')
             options.add_argument('--disable-gpu')
 
-        self.driver = Chrome(chrome_options=options, **kwargs)
+        self.driver = Chrome(options=options, **kwargs)
 
         self.element_class = WebDriverElement
 


### PR DESCRIPTION
'options' are replaced by 'chrome_options' in Selenium's Chrome webdriver.

See https://github.com/SeleniumHQ/selenium/blob/master/py/selenium/webdriver/chrome/webdriver.py#L50-L51
```
if chrome_options:
            warnings.warn('use options instead of chrome_options', DeprecationWarning)
            options = chrome_options
```