### PR TITLE
firefox: fix DeprecationWarning with firefox_options

### DIFF
--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -73,7 +73,7 @@ class WebDriver(BaseWebDriver):
         self.driver = Firefox(
             firefox_profile,
             capabilities=firefox_capabilities,
-            firefox_options=firefox_options,
+            options=firefox_options,
             timeout=timeout,
             **kwargs
         )


### PR DESCRIPTION
Fixes:

> DeprecationWarning: use options instead of firefox_options