### PR TITLE
Fix travis config for python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,11 @@ cache: pip
 language: python
 python:
   - "2.7"
-  - "3.7"
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 env:
   - DJANGO_VERSION=1.7.11 DRIVER=tests/test_djangoclient.py
   - DJANGO_VERSION=1.8.7 DRIVER=tests/test_djangoclient.py


### PR DESCRIPTION
In this [travis report](https://github.com/travis-ci/travis-ci/issues/9815), is a fix to the error with python 3.7. This PR apply this fix in splinter.