### PR TITLE
updated info about drivers to be current

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -97,9 +97,8 @@ Headless drivers
 The following drivers don't open a browser to run your actions (but has its own dependencies, check the
 specific docs for each driver):
 
-* :doc:`Chrome WebDriver </drivers/chrome>`
-* :doc:`Firefox WebDriver </drivers/firefox>`
-* :doc:`Phantomjs WebDriver </drivers/phantomjs>`
+* :doc:`Chrome WebDriver (headless option) </drivers/chrome>`
+* :doc:`Firefox WebDriver  (headless option) </drivers/firefox>`
 * :doc:`zope.testbrowser </drivers/zope.testbrowser>`
 * :doc:`django client </drivers/django>`
 * :doc:`flask client </drivers/flask>`

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -3,7 +3,7 @@ Why use Splinter?
 +++++++++++++++++
 
 Splinter is an abstraction layer on top of existing browser automation tools
-such as `Selenium`_, `PhantomJS`_ and `zope.testbrowser`_. It has a :doc:`high-level API
+such as `Selenium`_ and `zope.testbrowser`_. It has a :doc:`high-level API
 </api/index>` that makes it easy to write automated tests of web applications.
 
 For example, to fill out a form field with Splinter::
@@ -20,12 +20,18 @@ backends. With Splinter, you can use the same test code to do browser-based
 testing with Selenium as the backend and "headless" testing (no GUI) with
 zope.testbrowser as the backend.
 
-Splinter has drivers for :doc:`Chrome </drivers/chrome>` and :doc:`Firefox
-</drivers/firefox>` for  browser-based testing, and :doc:`zope.testbrowser
-</drivers/zope.testbrowser>` and :doc:`PhantomJS </drivers/phantomjs>` for
-headless testing.
+Splinter has drivers for browser-based testing on:
+
+* :doc:`Chrome </drivers/chrome>`
+* :doc:`Firefox </drivers/firefox>`
+* :doc:`Browsers on remote machines </drivers/remote>`
+
+For headless testing, Splinter has drivers for:
+
+* :doc:`zope.testbrowser </drivers/zope.testbrowser>`
+* :doc:`Django client </drivers/django>`
+* :doc:`Flask client </drivers/flask>`
 
 
 .. _Selenium: http://seleniumhq.org
 .. _zope.testbrowser: https://launchpad.net/zope.testbrowser
-.. _PhantomJS: http://phantomjs.org


### PR DESCRIPTION
Cleaned up outdated info that still mentioned PhantomJS (no longer supported in v0.9) and was missing other drivers. Minor stylistic edits for clarity.