### PR TITLE
Update tutorial and readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,9 @@ Sample code
        print "No, it wasn't found... We need to improve our SEO techniques"
 
    browser.quit()
+
+**Note:** if you don't provide any driver argument to the ``Browser`` function, ``firefox`` will be used (`Browser function documentation <https://splinter.readthedocs.io/en/latest/api/driver-and-element-api.html>`_).
+
 `What's new in splinter? <https://splinter.readthedocs.io/en/latest/news.html>`_
 
 First steps

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -29,7 +29,7 @@ First of all, import ``Browser`` class and instantiate it.
     from splinter import Browser
     browser = Browser()
 
-**Note:** if you don't provide any driver to ``Browser`` function, ``firefox`` will be used.
+**Note:** if you don't provide any driver to ``Browser`` function, ``firefox`` will be used (`Browser function documentation <https://splinter.readthedocs.io/en/latest/api/driver-and-element-api.html>`_).
 
 
 Visit Google website
@@ -127,7 +127,7 @@ Finally, the source code will be:
 
     from splinter import Browser
 
-    browser = Browser()
+    browser = Browser() # defaults to firefox
     browser.visit('http://google.com')
     browser.fill('q', 'splinter - python acceptance testing for web applications')
     browser.find_by_name('btnG').click()

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -29,7 +29,7 @@ First of all, import ``Browser`` class and instantiate it.
     from splinter import Browser
     browser = Browser()
 
-**Note:** if you don't provide any driver to ``Browser`` function, ``firefox`` will be used (`Browser function documentation <https://splinter.readthedocs.io/en/latest/api/driver-and-element-api.html>`_).
+**Note:** if you don't provide any driver argument to the ``Browser`` function, ``firefox`` will be used (`Browser function documentation <https://splinter.readthedocs.io/en/latest/api/driver-and-element-api.html>`_).
 
 
 Visit Google website


### PR DESCRIPTION
This pull request addresses issue #487 

Updated tutorial to highlight that the `Browser` function defaults to Firefox if there are no arguments.
Added the same note to the readme.