### PR TITLE
Update switch to alert

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -302,7 +302,7 @@ class BaseWebDriver(DriverAPI):
         return self.is_element_not_present(self.find_by_id, id, wait_time)
 
     def get_alert(self):
-        return AlertElement(self.driver.switch_to.alert())
+        return AlertElement(self.driver.switch_to_alert())
 
     def is_text_present(self, text, wait_time=None):
         wait_time = wait_time or self.wait_time


### PR DESCRIPTION
The syntax for switch to alert has changed from
`switch_to.alert()` to `switch_to_alert()`, updated webdriver init to reflect this change.