### PR TITLE
Made full TOC appear in sidebar for better navigation. Various language edits.

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,2 +1,2 @@
-Sphinx==1.2.3
-sphinx-rtd-theme==0.1.6
+Sphinx>=1.7.8
+sphinx-rtd-theme>=0.1.8

--- a/docs/browser.rst
+++ b/docs/browser.rst
@@ -4,13 +4,13 @@
 
 .. meta::
     :description: Browser
-    :keywords: splinter, python, tutorial, browser, firefox, chrome, zope, testebrowser
+    :keywords: splinter, python, tutorial, browser, firefox, chrome, zope.testbrowser
 
 +++++++
 Browser
 +++++++
 
-To use splinter you need create a Browser instance:
+To use splinter you need to create a Browser instance:
 
 .. highlight:: python
 
@@ -30,10 +30,18 @@ Or, you can use it by a ``context manager``, through the ``with`` statement:
         # stuff using the browser
 
 This last example will create a new browser window and close it when the cursor
-reach the code outside the ``with`` statement, automatically.
+reaches the code outside the ``with`` statement, automatically.
 
-splinter support three drivers: chrome, firefox and zopetestbrowser
+splinter supports the following drivers:
+* :doc:`Chrome </drivers/chrome>`
+* :doc:`Firefox </drivers/firefox>`
+* :doc:`Browsers on remote machines </drivers/remote>`
+* :doc:`zope.testbrowser </drivers/zope.testbrowser>`
+* :doc:`Django client </drivers/django>`
+* :doc:`Flask client </drivers/flask>`
 
+The following examples create new Browser instances for specific drivers:
+  
 .. highlight:: python
 
 ::
@@ -94,7 +102,7 @@ exposed in v0.6.0 and earlier.
 Reload a page
 =============
 
-You can reload a page using ``reload`` method:
+You can reload a page using the ``reload`` method:
 
 .. highlight:: python
 
@@ -106,7 +114,7 @@ You can reload a page using ``reload`` method:
 Navigate through the history
 ============================
 
-You can back and forward on your browsing history using ``back`` and ``forward`` methods:
+You can move back and forward through your browsing history using the ``back`` and ``forward`` methods:
 
 .. highlight:: python
 
@@ -157,7 +165,7 @@ The visited page's url can be accessed by the ``url`` attribute:
 Changing Browser User-Agent
 ===========================
 
-You can pass User-Agent on Browser instantiation.
+You can pass a User-Agent header on Browser instantiation.
 
 .. highlight:: python
 

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -7,7 +7,7 @@
     :keywords: splinter, python, cobrateam, community, atdd, tests, acceptance tests, web applications
 
 +++++++++
-community
+Community
 +++++++++
 
 mailing list

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -7,7 +7,7 @@
     :keywords: splinter, python, contribution, open source, testing, web application, atdd
 
 ++++++++++
-contribute
+Contribute
 ++++++++++
 
 * Source hosted at `GitHub <http://github.com/cobrateam/splinter>`_
@@ -48,15 +48,21 @@ When adding support for new drivers, we usually work in a separated branch.
 writing docs
 ============
 
-Splinter documentation is written using `Sphinx <http://sphinx.pocoo.org/>`_, which uses `RST <http://docutils.sourceforge.net/rst.html>`_. Check these tools docs to learn how to write docs for Splinter.
+Splinter documentation is written using `Sphinx 
+<http://sphinx.pocoo.org/>`_, which uses `RST 
+<http://docutils.sourceforge.net/rst.html>`_. We use the `Read the Docs Sphinx Theme <https://sphinx-rtd-theme.readthedocs.io/en/latest/index.html>`_. Check these tools' docs to learn how to write docs for Splinter.
 
 building docs
 =============
 
-In order to build the HTML docs, just run on terminal:
+In order to build the HTML docs, just navigate to the project folder
+(the main folder, not the ``docs`` folder) and run the following on the terminal:
 
 .. highlight:: bash
 
 ::
 
     $ make doc
+
+The requirements for building the docs are specified in
+``doc-requirements.txt`` in the project folder.

--- a/docs/drivers/chrome.rst
+++ b/docs/drivers/chrome.rst
@@ -53,7 +53,7 @@ The recommended way is by using `Homebrew <http://mxcl.github.com/homebrew/>`_:
 Linux
 -----
 
-Go to the `download page on Chromium project
+Go to the `download page on the Chromium project
 <https://sites.google.com/a/chromium.org/chromedriver/downloads>`_ and choose
 the correct version for your Linux installation. Then extract the downloaded file in a
 directory in the ``PATH`` (e.g. ``/usr/bin``). You can also extract it to any
@@ -103,7 +103,7 @@ the ``Browser`` instance:
     from splinter import Browser
     browser = Browser('chrome')
 
-**Note:** if you don't provide any driver to ``Browser`` function, ``firefox`` will be used.
+**Note:** if you don't provide any driver to the ``Browser`` function, ``firefox`` will be used.
 
 **Note:** if you have trouble with ``$HOME/.bash_profile``, you can try ``$HOME/.bashrc``.
 

--- a/docs/drivers/django.rst
+++ b/docs/drivers/django.rst
@@ -8,7 +8,7 @@
 
 ++++++++++++++++
 django client
-+++++++++++++
+++++++++++++++++
 
 .. module:: splinter.driver.djangoclient
 

--- a/docs/drivers/firefox.rst
+++ b/docs/drivers/firefox.rst
@@ -41,7 +41,7 @@ the ``Browser`` instance:
 
 
 Using headless option for Firefox
------------------------
+-----------------------------------
 
 Starting with Firefox 55, we can run Firefox as a headless browser in Linux.
 
@@ -54,7 +54,7 @@ Starting with Firefox 55, we can run Firefox as a headless browser in Linux.
 
 
 Using incognito option for Firefox
------------------------
+------------------------------------
 
 We can run Firefox as a private browser.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. Copyright 2012 splinter authors. All rights reserved.
+.. Copyright 2012-2018 splinter authors. All rights reserved.
    Use of this source code is governed by a BSD-style
    license that can be found in the LICENSE file.
 
@@ -35,16 +35,17 @@ Sample code
         else:
             print("No, it wasn't found... We need to improve our SEO techniques")
 
-**Note:** if you don't provide any driver to ``Browser`` function, ``firefox`` will be used.
+**Note:** if you don't provide any driver to the ``Browser`` function, ``firefox`` will be used.
 
 Features
 --------
 
 * simple api
-* multi webdrivers (chrome webdriver, firefox webdriver, phantomjs webdriver, zopetestbrowser, remote webdriver)
+* multiple webdrivers (chrome, firefox, zopetestbrowser, remote
+  webdriver, Django, Flask)
 * css and xpath selectors
-* support to iframe and alert
-* execute javascript
+* support for iframes and alerts
+* can execute javascript
 * works with ajax and async javascript
 
 :doc:`what's new in splinter? </news>`
@@ -89,12 +90,11 @@ The following drivers open a browser to run your actions:
 
 * :doc:`Chrome WebDriver </drivers/chrome>`
 * :doc:`Firefox WebDriver </drivers/firefox>`
-* :doc:`Remote WebDriver </drivers/remote>`
 
 Headless drivers
 ++++++++++++++++
 
-The following drivers don't open a browser to run your actions (but has its own dependencies, check the
+The following drivers don't open a browser to run your actions (but each has its own dependencies, check the
 specific docs for each driver):
 
 * :doc:`Chrome WebDriver (headless option) </drivers/chrome>`
@@ -119,3 +119,58 @@ Get in touch and contribute
 * :doc:`Contribute </contribute>`
 * :doc:`Writing new drivers </contribute/writing-new-drivers>`
 * :doc:`Setting up your splinter development environment </contribute/setting-up-your-development-environment>`
+
+.. toctree::
+   :caption: Getting Started
+   :hidden:
+
+   why
+   install
+   tutorial
+
+.. toctree::
+   :caption: Browsing and Interactions
+   :hidden:
+      
+   browser
+   finding
+   mouse-interaction
+   elements-in-the-page
+   matchers
+   cookies
+   screenshot
+      
+.. toctree::
+   :caption: JavaScript
+   :hidden:
+
+   javascript
+
+.. toctree::
+   :caption: Drivers
+   :hidden:
+
+   drivers/chrome
+   drivers/firefox
+   drivers/remote
+   drivers/zope.testbrowser
+   drivers/django
+   drivers/flask
+
+.. toctree::
+   :caption: More
+   :hidden:
+      
+   http-status-code-and-exception
+   http-proxies
+   iframes-and-alerts
+   api/index
+
+.. toctree::
+   :caption: Get in touch and contribute
+   :hidden:
+
+   community
+   contribute
+   contribute/writing-new-drivers
+   contribute/setting-up-your-development-environment

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -97,9 +97,8 @@ Headless drivers
 The following drivers don't open a browser to run your actions (but has its own dependencies, check the
 specific docs for each driver):
 
-* :doc:`Chrome WebDriver </drivers/chrome>`
-* :doc:`Firefox WebDriver </drivers/firefox>`
-* :doc:`Phantomjs WebDriver </drivers/phantomjs>`
+* :doc:`Chrome WebDriver (headless option) </drivers/chrome>`
+* :doc:`Firefox WebDriver  (headless option) </drivers/firefox>`
 * :doc:`zope.testbrowser </drivers/zope.testbrowser>`
 * :doc:`django client </drivers/django>`
 * :doc:`flask client </drivers/flask>`

--- a/docs/screenshot.rst
+++ b/docs/screenshot.rst
@@ -19,7 +19,8 @@ Splinter can take current view screenshot easily:
     browser = Browser()
     screenshot_path = browser.screenshot('absolute_path/your_screenshot.png')
 
-You should use the absolute path to save screenshot, if not screenshot will save in a temporary file.
+You should use the absolute path to save screenshot. If you don't use
+an absolute path, the screenshot will be saved in a temporary file.
 
 Take a full view screenshot:
 
@@ -30,16 +31,16 @@ Take a full view screenshot:
     browser = Browser()
     screenshot_path = browser.screenshot('absolute_path/your_screenshot.png', full=True)
 
-++++++++++++++++++
+++++++++++++++++++++++++++++
 Take element screenshot
-++++++++++++++++++
+++++++++++++++++++++++++++++
 First, if you want to use this function, you should install the Pillow dependency:
 
 ::
 
     pip install Pillow
 
-If the element in current view:
+If the element in the current view:
 
 .. highlight:: python
 
@@ -49,7 +50,7 @@ If the element in current view:
     browser.visit('http://example.com')
     screenshot_path = browser.find_by_xpath('xpath_rule').first.screenshot('absolute_path/your_screenshot.png')
 
-If the element not in current view, you should do it like this:
+If the element not in the current view, you should do it like this:
 
 .. highlight:: python
 

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -3,7 +3,7 @@ Why use Splinter?
 +++++++++++++++++
 
 Splinter is an abstraction layer on top of existing browser automation tools
-such as `Selenium`_, `PhantomJS`_ and `zope.testbrowser`_. It has a :doc:`high-level API
+such as `Selenium`_ and `zope.testbrowser`_. It has a :doc:`high-level API
 </api/index>` that makes it easy to write automated tests of web applications.
 
 For example, to fill out a form field with Splinter::
@@ -20,12 +20,18 @@ backends. With Splinter, you can use the same test code to do browser-based
 testing with Selenium as the backend and "headless" testing (no GUI) with
 zope.testbrowser as the backend.
 
-Splinter has drivers for :doc:`Chrome </drivers/chrome>` and :doc:`Firefox
-</drivers/firefox>` for  browser-based testing, and :doc:`zope.testbrowser
-</drivers/zope.testbrowser>` and :doc:`PhantomJS </drivers/phantomjs>` for
-headless testing.
+Splinter has drivers for browser-based testing on:
+
+* :doc:`Chrome </drivers/chrome>`
+* :doc:`Firefox </drivers/firefox>`
+* :doc:`Browsers on remote machines </drivers/remote>`
+
+For headless testing, Splinter has drivers for:
+
+* :doc:`zope.testbrowser </drivers/zope.testbrowser>`
+* :doc:`Django client </drivers/django>`
+* :doc:`Flask client </drivers/flask>`
 
 
 .. _Selenium: http://seleniumhq.org
 .. _zope.testbrowser: https://launchpad.net/zope.testbrowser
-.. _PhantomJS: http://phantomjs.org


### PR DESCRIPTION
Before, the full TOC was not available in the sidebar, so if you clicked on a link to the Installation page (for example), you would have to navigate back to Home to get to any other page. I updated  doc-requirements.txt to use the latest Read the Docs theme, which allows for captions in the TOC. Then, I put a few toctree directives in index.rst so that the full TOC would appear in the sidebar, with captions separating the different categories.

I also made various language edits for clarity, grammar, and punctuation.

Finally, Sphinx was throwing some warnings about title underlines being too short. I don't think they affected the build, but they were extra noise within legitimate warnings, so I made those underlines longer to get rid of the warnings.