### PR TITLE
Add support for retrieval of response headers to Flask client

### DIFF
--- a/splinter/driver/__init__.py
+++ b/splinter/driver/__init__.py
@@ -596,6 +596,15 @@ class DriverAPI(InheritedDocs("_DriverAPI", (object,), {})):
             "%s doesn't support cookies manipulation" % self.driver_name
         )
 
+    @property
+    def response_headers(self):
+        """
+        Headers from the most recent response.
+        """
+        raise NotImplementedError(
+            "%s doesn't support access to the response headers." % self.driver_name
+        )
+
 
 class ElementAPI(InheritedDocs("_ElementAPI", (object,), {})):
     """

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -103,3 +103,10 @@ class FlaskClient(LxmlDriver):
     @property
     def html(self):
         return self._response.get_data(as_text=True)
+
+    @property
+    def response_headers(self):
+        try:
+            return self._response.headers
+        except AttributeError:
+            return None

--- a/tests/test_flaskclient.py
+++ b/tests/test_flaskclient.py
@@ -7,6 +7,7 @@
 import os
 import unittest
 
+import werkzeug
 from splinter import Browser
 from .base import BaseBrowserTests
 from .fake_webapp import app, EXAMPLE_APP
@@ -105,6 +106,10 @@ class FlaskClientDriverTest(
         """
         with self.assertRaises(NotImplementedError):
             self.browser.type("query", "with type method", slowly=True)
+
+    def test_response_headers(self):
+        self.browser.visit(EXAMPLE_APP)
+        self.assertIsInstance(self.browser.response_headers, werkzeug.datastructures.Headers)
 
     def test_slowly_typing_on_element(self):
         """


### PR DESCRIPTION
This is functionality I've needed when using Splinter with behave to test web apps.