### PR TITLE
setup.py: add six to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     + [("Programming Language :: Python :: %s" % x) for x in "2.6 2.7 3.3 3.4".split()],
     packages=find_packages(exclude=["docs", "tests", "samples"]),
     include_package_data=True,
-    install_requires=["selenium>=3.141.0"],
+    install_requires=["selenium>=3.141.0", "six"],
     extras_require={
         "zope.testbrowser": ["zope.testbrowser>=5.2.4", "lxml>=4.2.4", "cssselect"],
         "django": ["Django>=1.7.11;python_version<'3.0'", "Django>=2.0.6;python_version>'3.3'", "lxml>=2.3.6", "cssselect", "six"],


### PR DESCRIPTION
Commit dcfba0ea808dda8224d2f52e64f099a2bbf2b5f8 started using the six
module in splinter/driver/webdriver/__init__.py, but did not declare
the dependency in setup.py as it should have.

Fixes #671.