### PR TITLE
Use 'switch_to.alert' instead of deprecated 'switch_to_alert'

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -302,7 +302,7 @@ class BaseWebDriver(DriverAPI):
         return self.is_element_not_present(self.find_by_id, id, wait_time)
 
     def get_alert(self):
-        return AlertElement(self.driver.switch_to_alert())
+        return AlertElement(self.driver.switch_to.alert())
 
     def is_text_present(self, text, wait_time=None):
         wait_time = wait_time or self.wait_time


### PR DESCRIPTION
```
=== warnings summary =====================================================
.../splinter/driver/webdriver/__init__.py:305:
      DeprecationWarning: use driver.switch_to.alert instead
  return AlertElement(self.driver.switch_to_alert())
=======================================================================
```

See the docs: https://selenium-python.readthedocs.io/api.html?highlight=switch_to#selenium.webdriver.remote.webdriver.WebDriver.switch_to_alert