### PR TITLE
Browser.get_alert() returns Alert instead of a wrapper object

### DIFF
--- a/docs/iframes-and-alerts.rst
+++ b/docs/iframes-and-alerts.rst
@@ -28,9 +28,9 @@ Handling alerts and prompts
 
     Chrome support for alerts and prompts is new in Splinter 0.4.
 
-**IMPORTANT:** Only webdrivers (Firefox and Chrome) has support for alerts and prompts.
+**IMPORTANT:** Only webdriver (Firefox and Chrome) has support for alerts and prompts.
 
-You can deal with alerts and prompts using the ``get_alert`` method.
+You can interact with alerts and prompts using the ``get_alert`` method.
 
 .. highlight:: python
 
@@ -42,7 +42,7 @@ You can deal with alerts and prompts using the ``get_alert`` method.
     alert.dismiss()
 
 
-In case of prompts, you can answer it using the ``fill_with`` method.
+In case of prompts, you can answer it using the ``send_keys`` method.
 
 .. highlight:: python
 
@@ -50,12 +50,12 @@ In case of prompts, you can answer it using the ``fill_with`` method.
 
     prompt = browser.get_alert()
     prompt.text
-    prompt.fill_with('text')
+    prompt.send_keys('text')
     prompt.accept()
     prompt.dismiss()
 
 
-You can use the ``with`` statement to interacte with both alerts and prompts too.
+You can also use the ``with`` statement to interact with both alerts and prompts.
 
 .. highlight:: python
 
@@ -64,6 +64,6 @@ You can use the ``with`` statement to interacte with both alerts and prompts too
     with browser.get_alert() as alert:
         alert.do_stuff()
 
-If there's not any prompt or alert, ``get_alert`` will return ``None``.
+If there's no prompt or alert, ``get_alert`` will return ``None``.
 Remember to always use at least one of the alert/prompt ending methods (accept and dismiss).
-Otherwise your browser instance will be frozen until you accept or dismiss the alert/prompt correctly.
+Otherwise, your browser instance will be frozen until you accept or dismiss the alert/prompt correctly.

--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -11,6 +11,7 @@ import tempfile
 import time
 from contextlib import contextmanager
 
+from selenium.webdriver.common.alert import Alert
 from selenium.common.exceptions import NoSuchElementException, WebDriverException, StaleElementReferenceException
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions as EC
@@ -28,6 +29,17 @@ if sys.version_info[0] > 2:
 else:
     _meth_func = "im_func"
     _func_name = "func_name"
+
+# Patch contextmanager onto Selenium's Alert
+def alert_enter(self):
+    return self
+
+def alert_exit(self, type, value, traceback):
+    pass
+
+Alert.__enter__ = alert_enter
+Alert.__exit__ = alert_exit
+Alert.fill_with = Alert.send_keys
 
 
 class switch_window:
@@ -309,7 +321,7 @@ class BaseWebDriver(DriverAPI):
 
         alert = WebDriverWait(self.driver, wait_time).until(EC.alert_is_present())
 
-        return AlertElement(alert)
+        return alert
 
     def is_text_present(self, text, wait_time=None):
         wait_time = wait_time or self.wait_time
@@ -824,24 +836,3 @@ class WebDriverElement(ElementAPI):
 
     def __getitem__(self, attr):
         return self._element.get_attribute(attr)
-
-
-class AlertElement(object):
-    def __init__(self, alert):
-        self._alert = alert
-        self.text = alert.text
-
-    def accept(self):
-        self._alert.accept()
-
-    def dismiss(self):
-        self._alert.dismiss()
-
-    def fill_with(self, text):
-        self._alert.send_keys(text)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, traceback):
-        pass


### PR DESCRIPTION
- Remove `fill_with` method, since it just wraps `send_keys`

The purpose of this PR is to change Browser.get_alert() such that it provides access to the real selenium Alert object instead of a wrapper. The context manager functionality has been preserved.