### PR TITLE
Fix test_clicking_submit_input_posts_empty_value_if_value_not_present

### DIFF
--- a/tests/form_elements.py
+++ b/tests/form_elements.py
@@ -42,7 +42,7 @@ class FormElementsTest(object):
         self.browser.find_by_css('input[name="submit-input-no-value"]').click()
         body_text = self.browser.find_by_xpath("/descendant-or-self::*").text.strip()
         self.assertTrue(
-            re.match(r"^submit-input-no-value:(?:| Submit)$", body_text),
+            re.match(r"^submit-input-no-value:(?:| Submit| Submit Query)$", body_text),
             repr(body_text),
         )
 


### PR DESCRIPTION
In Chrome, the default value for an `input type="submit` is "Submit". However in Firefox its "Submit Query".