### PR TITLE
Fix test_capabilities_set. 

### DIFF
--- a/tests/test_webdriver_firefox.py
+++ b/tests/test_webdriver_firefox.py
@@ -92,15 +92,16 @@ class FirefoxBrowserProfilePreferencesTest(unittest.TestCase):
 class FirefoxBrowserCapabilitiesTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        capabilities = {"acceptSslCerts": False, "javascriptEnabled": True}
-        cls.browser = Browser("firefox", capabilities=capabilities, headless=True)
+        cls.browser = Browser(
+            "firefox",
+            capabilities={"pageLoadStrategy": "eager"},
+            headless=True,
+        )
 
     def test_capabilities_set(self):
         capabilities = self.browser.driver.capabilities
-        self.assertIn("acceptSslCerts", capabilities)
-        self.assertEqual(False, capabilities.get("acceptSslCerts"))
-        self.assertIn("javascriptEnabled", capabilities)
-        self.assertEqual(True, capabilities.get("javascriptEnabled"))
+        self.assertIn("pageLoadStrategy", capabilities)
+        self.assertEqual("eager", capabilities.get("pageLoadStrategy"))
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
acceptSslCerts has been deprecated in favour of acceptInsecureCerts. However, the current implementation of webdriver will always override a desired capability in favour of an Options value, and the default Options object has this value set to a true value.