### PR TITLE
Fix mouse_out method

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -744,7 +744,8 @@ class WebDriverElement(ElementAPI):
         Currently works only on Chrome driver.
         """
         self.scroll_to()
-        ActionChains(self.parent.driver).move_by_offset(0, 0).click().perform()#5000, 5000)
+        ActionChains(self.parent.driver).move_to_element_with_offset(
+            self._element, -10, -10).click().perform()
 
     def double_click(self):
         """

--- a/tests/fake_webapp.py
+++ b/tests/fake_webapp.py
@@ -24,6 +24,7 @@ EXAMPLE_TYPE_HTML = read_static("type.html")
 EXAMPLE_POPUP_HTML = read_static("popup.html")
 EXAMPLE_NO_BODY_HTML = read_static("no-body.html")
 EXAMPLE_REDIRECT_LOCATION_HTML = read_static("redirect-location.html")
+EXAMPLE_MOUSE_HTML = read_static("mouse.html")
 
 # Functions for http basic auth.
 # Taken verbatim from http://flask.pocoo.org/snippets/8/
@@ -150,6 +151,11 @@ def redirected():
 @app.route("/redirect-location")
 def redirect_location():
     return EXAMPLE_REDIRECT_LOCATION_HTML
+
+
+@app.route("/mouse")
+def mouse():
+    return EXAMPLE_MOUSE_HTML
 
 
 def start_flask_app(host, port):

--- a/tests/mouse_interaction.py
+++ b/tests/mouse_interaction.py
@@ -23,6 +23,16 @@ class MouseInteractionTest(object):
         element.mouse_out()
         self.assertTrue(self.browser.is_element_not_present_by_id("what-is-your-name"))
 
+    def test_mouse_out_top_left(self):
+        """Should be able to perform a mouse out on an element,
+        even if the element is at the top left corner of the screen.
+        """
+        self.browser.visit(EXAMPLE_APP + '/mouse')
+        element = self.browser.find_by_css(".add-element-mouseover")
+        element.mouse_over()
+        element.mouse_out()
+        self.assertTrue(self.browser.is_element_not_present_by_id("what-is-your-name"))
+
     def test_double_click(self):
         "double click should shows a hidden element"
         self.browser.visit(EXAMPLE_APP)

--- a/tests/static/mouse.html
+++ b/tests/static/mouse.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML>
+
+<html>
+  <head>
+    <title>Example Title</title>
+    <style>
+        .add-element-mouseover {
+            background-color: cyan;
+            position: absolute;
+            left: 0;
+            top: 0;
+        }
+
+    </style>
+    <script type="text/javascript" src="/static/jquery.min.js"></script>
+    <script type="text/javascript" src="/static/jquery-ui-1.8.16.custom.min.js"></script>
+    <script type="text/javascript">
+        $(document).ready(function() {
+           $(".add-element-mouseover").mouseover(function () {
+                $('body').append('<label for="what-is-your-name" class="over-label">What is your name?</label>');
+                $('body').append('<input type="text" id="what-is-your-name" class="over-input" name="whatsname" />');
+           });
+
+           $(".add-element-mouseover").mouseout(function () {
+                $('.over-label').remove();
+                $('.over-input').remove();
+           });
+        });
+    </script>
+  </head>
+  <body>
+    <a class="add-element-mouseover" href="#">Element at X:0 Y:0</a>
+
+  </body>
+</html>

--- a/tests/test_webdriver_remote.py
+++ b/tests/test_webdriver_remote.py
@@ -52,6 +52,11 @@ class RemoteBrowserTest(WebDriverTests, unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.browser.find_by_id("visible").mouse_out()
 
+    def test_mouse_out_top_left(self):
+        "Remote should not support mouseout"
+        with self.assertRaises(NotImplementedError):
+            self.browser.find_by_id("visible").mouse_out()
+
     def test_double_click(self):
         "Remote should not support double_click"
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
Changes the behaviour of the mouse_out() method to move to (-10, -10) relative to the top left of the element.

+ Add a new test where the hovered element is at the top-left of the browser window.

This fixes the mouse_out behaviour in Chrome.