### PR TITLE
Fix test_webdriver_chrome test_attach_file

### DIFF
--- a/tests/test_webdriver_chrome.py
+++ b/tests/test_webdriver_chrome.py
@@ -44,7 +44,11 @@ class ChromeBrowserTest(WebDriverTests, unittest.TestCase):
 
         html = self.browser.html
         self.assertIn("text/plain", html)
-        self.assertIn(open(file_path).read().encode("utf-8"), html)
+
+        with open(file_path) as f:
+            expected = str(f.read().encode("utf-8"))
+
+        self.assertIn(expected, html)
 
     def test_should_support_with_statement(self):
         with Browser("chrome"):


### PR DESCRIPTION
Convert the bytes object into a string for python 3.6+ compatibility.