### PR TITLE
Fix popups tests

### DIFF
--- a/tests/popups.py
+++ b/tests/popups.py
@@ -38,6 +38,9 @@ class PopupWindowsTest(object):
         self.assertTrue(self.browser.windows.current.is_current)
         self.assertFalse(self.browser.windows.current.next.is_current)
 
+        # Close popup window
+        self.browser.windows.current.close_others()
+
     def test_set_is_current_to_True_sets_window_to_current(self):
         self.browser.find_by_id("open-popup").click()
         next_window = self.browser.windows.current.next


### PR DESCRIPTION
Some tests fail in Chrome due to a leftover popup window from a previous test.

The reason appears to be that if a popup window is already open, each browser has different behaviour when opening a new popup after a URL redirection.
- Chrome: A new window is opened.
- Firefox: The existing popup window is used.

This can be reproduced manually using the example app:

Steps to Reproduce:
1 - Run the example app and go to localhost:5000
2 - Open a popup window
3 - Navigate to google.com
4 - Navigate to localhost:5000 (Do not use a back button)
5 - Open a popup window 