### PR TITLE
Fix ElementList.__getattr__() to no longer hide ElementNotFound

### DIFF
--- a/splinter/element_list.py
+++ b/splinter/element_list.py
@@ -74,7 +74,7 @@ class ElementList(object):
     def __getattr__(self, name):
         try:
             return getattr(self.first, name)
-        except (ElementDoesNotExist, AttributeError):
+        except AttributeError:
             try:
                 return getattr(self._container, name)
             except AttributeError:

--- a/tests/test_element_list.py
+++ b/tests/test_element_list.py
@@ -71,12 +71,12 @@ class ElementListTest(unittest.TestCase):
             the_list = ElementList([Person(), Person()])
             the_list.talk()
 
-    def test_attribute_error_for_empty(self):
+    def test_attribute_error_method_for_empty(self):
         """
-        should raise AttributeError when the list is empty
-        and someone tries to access a method or property on it
+        should raise ElementDoesNotExist when the list is empty
+        and someone tries to access a method or property on the child element.
         """
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(ElementDoesNotExist):
             the_list = ElementList([])
             the_list.unknown_method()
 


### PR DESCRIPTION
When elements aren't found on the page, calling methods like ElementList.click() didn't raise this error. Instead it would report "AttributeError: 'ElementList' object has no attribute 'click'" which confuses users to look at other places than the actual error.