### PR TITLE
Fix Firefox headless mode to handle custom firefox_binary option

### DIFF
--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -4,6 +4,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 import os
+import six
 
 from selenium.webdriver import DesiredCapabilities, Firefox
 from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
@@ -16,11 +17,6 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from selenium.webdriver.firefox.options import Options
-
-try:
-    basestring
-except NameError:  # Python 3.x
-    basestring = str
 
 
 class WebDriver(BaseWebDriver):
@@ -69,7 +65,7 @@ class WebDriver(BaseWebDriver):
         if headless:
             os.environ.update({"MOZ_HEADLESS": "1"})
             if 'firefox_binary' in kwargs:
-                if isinstance(kwargs['firefox_binary'], str):
+                if isinstance(kwargs['firefox_binary'], six.string_types):
                     binary = FirefoxBinary(kwargs['firefox_binary'])
                 else:
                     binary = kwargs['firefox_binary']

--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -17,6 +17,11 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from selenium.webdriver.firefox.options import Options
 
+try:
+    basestring
+except NameError:  # Python 3.x
+    basestring = str
+
 
 class WebDriver(BaseWebDriver):
 
@@ -63,7 +68,13 @@ class WebDriver(BaseWebDriver):
 
         if headless:
             os.environ.update({"MOZ_HEADLESS": "1"})
-            binary = FirefoxBinary()
+            if 'firefox_binary' in kwargs:
+                if isinstance(kwargs['firefox_binary'], str):
+                    binary = FirefoxBinary(kwargs['firefox_binary'])
+                else:
+                    binary = kwargs['firefox_binary']
+            else:
+                binary = FirefoxBinary()
             binary.add_command_line_options("-headless")
             kwargs["firefox_binary"] = binary
 


### PR DESCRIPTION
This commit fixes Firefox headless mode so that it respects the possible `firefox_binary` option.

Previously a custom Firefox path string or browser object passed in `kwargs['firefox_binary']` would not work in headless mode. Instead the option was silently overwritten and a default executable location was used.