### PR TITLE
Fix Firefox driver to respect headless option in subsequent calls

### DIFF
--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -4,6 +4,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 import os
+import six
 
 from selenium.webdriver import DesiredCapabilities, Firefox
 from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
@@ -16,11 +17,6 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from selenium.webdriver.firefox.options import Options
-
-try:
-    basestring
-except NameError:  # Python 3.x
-    basestring = str
 
 
 class WebDriver(BaseWebDriver):
@@ -69,7 +65,7 @@ class WebDriver(BaseWebDriver):
         if headless:
             os.environ.update({"MOZ_HEADLESS": "1"})
             if 'firefox_binary' in kwargs:
-                if isinstance(kwargs['firefox_binary'], str):
+                if isinstance(kwargs['firefox_binary'], six.string_types):
                     binary = FirefoxBinary(kwargs['firefox_binary'])
                 else:
                     binary = kwargs['firefox_binary']

--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -73,6 +73,9 @@ class WebDriver(BaseWebDriver):
                 binary = FirefoxBinary()
             binary.add_command_line_options("-headless")
             kwargs["firefox_binary"] = binary
+        else:
+            if "MOZ_HEADLESS" in os.environ:
+                del os.environ["MOZ_HEADLESS"]
 
         if incognito:
             firefox_options.add_argument("-private")

--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -17,6 +17,11 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from selenium.webdriver.firefox.options import Options
 
+try:
+    basestring
+except NameError:  # Python 3.x
+    basestring = str
+
 
 class WebDriver(BaseWebDriver):
 
@@ -63,7 +68,13 @@ class WebDriver(BaseWebDriver):
 
         if headless:
             os.environ.update({"MOZ_HEADLESS": "1"})
-            binary = FirefoxBinary()
+            if 'firefox_binary' in kwargs:
+                if isinstance(kwargs['firefox_binary'], str):
+                    binary = FirefoxBinary(kwargs['firefox_binary'])
+                else:
+                    binary = kwargs['firefox_binary']
+            else:
+                binary = FirefoxBinary()
             binary.add_command_line_options("-headless")
             kwargs["firefox_binary"] = binary
 

--- a/tests/test_webdriver_firefox.py
+++ b/tests/test_webdriver_firefox.py
@@ -50,7 +50,7 @@ class FirefoxBrowserTest(WebDriverTests, FirefoxBase, unittest.TestCase):
         self.assertIn(open(file_path, "rb").read().decode("utf-8"), html)
 
     def test_should_support_with_statement(self):
-        with Browser("firefox"):
+        with Browser("firefox", headless=True):
             pass
 
 


### PR DESCRIPTION
This commit clears the `MOZ_HEADLESS` environment variable explicitly when the `headless` option is not set. Selenium passes the environment variables to Firefox as they are, and the environment variable alone is enough to cause a headless launch.

Previously a single headless launch would cause all subsequent launches be headless regardless the option being set or not.