### PR TITLE
Browser.get_alert() returns None if no alert exists

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 import warnings
 
 from selenium.webdriver.common.alert import Alert
-from selenium.common.exceptions import NoSuchElementException, WebDriverException, StaleElementReferenceException
+from selenium.common.exceptions import NoSuchElementException, WebDriverException, StaleElementReferenceException, TimeoutException
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -366,9 +366,11 @@ class BaseWebDriver(DriverAPI):
     def get_alert(self, wait_time=None):
         wait_time = wait_time or self.wait_time
 
-        alert = WebDriverWait(self.driver, wait_time).until(EC.alert_is_present())
-
-        return alert
+        try:
+            alert = WebDriverWait(self.driver, wait_time).until(EC.alert_is_present())
+            return alert
+        except TimeoutException:
+            return None
 
     def is_text_present(self, text, wait_time=None):
         wait_time = wait_time or self.wait_time

--- a/tests/base.py
+++ b/tests/base.py
@@ -237,6 +237,11 @@ class WebDriverTests(
             self.assertEqual("This is an alert example.", alert.text)
             alert.accept()
 
+    def test_get_alert_return_none_if_no_alerts(self):
+        "should return None if no alerts available"
+        alert = self.browser.get_alert()
+        self.assertEqual(None, alert)
+
     def test_can_select_a_option_via_element_text(self):
         "should provide a way to select a option via element"
         self.assertFalse(self.browser.find_option_by_value("rj").selected)


### PR DESCRIPTION
A fix for issue #387. Have `browser.get_alert()` return `None` if no alert exists, instead of Selenium exception.