### PR TITLE
[Bugfix & Enhancement] Screenshot

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -610,7 +610,7 @@ class BaseWebDriver(DriverAPI):
         os.close(fd)
 
         self.capture_screenshot(filename, full)
-        
+
         return filename
 
     def capture_screenshot(self, filename, full=False, waiting_time=0):
@@ -926,9 +926,15 @@ class WebDriverElement(ElementAPI):
 
         return filename
 
+    # TODO Uncomment this method and remove the hotfix one once the upstream issue(https://bugs.chromium.org/p/chromedriver/issues/detail?id=3154) has been fixed.
+    # def capture_screenshot(self, filename, waiting_time=0):
+    #     if waiting_time > 0:
+    #         time.sleep(waiting_time)
+
+    #     return self._element.screenshot(filename)
 
     def capture_screenshot(self, filename, waiting_time=0):
-        base64_string = self.screenshot_as_base64(waiting_time)
+        base64_string = self.capture_screenshot_as_base64(waiting_time)
         png = base64.b64decode(base64_string.encode('ascii'))
 
         try:
@@ -941,12 +947,18 @@ class WebDriverElement(ElementAPI):
 
         return True
 
+    # TODO Uncomment this method and remove the hotfix one once the upstream issue(https://bugs.chromium.org/p/chromedriver/issues/detail?id=3154) has been fixed.
+    # def capture_screenshot_as_base64(self, waiting_time=0):
+    #     if waiting_time > 0:
+    #         time.sleep(waiting_time)
+        
+    #     return self._element.screenshot_as_base64
+
     def capture_screenshot_as_base64(self, waiting_time=0):
         self.parent.full_screen()
 
         if waiting_time > 0:
             time.sleep(waiting_time)
-        
         
         location = self._element.location
         size = self._element.size

--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -643,7 +643,7 @@ class BaseWebDriver(DriverAPI):
                 'y': viewport['y'],
                 'width': viewport['width'],
                 'height': viewport['height'],
-                'scale': self.driver.execute_script('return window.devicePixelRatio')
+                'scale': 1
             }
         })
 
@@ -1006,27 +1006,17 @@ class WebDriverElement(ElementAPI):
     #     return self._element.screenshot_as_base64
 
     def capture_screenshot_as_base64(self, waiting_time=0):
-        self.parent.full_screen()
-
-        if waiting_time > 0:
-            time.sleep(waiting_time)
-        
         location = self._element.location
         size = self._element.size
 
-        response = self.parent.driver.execute_cdp_cmd('Page.captureScreenshot', {
-            'clip': {
-                'x': location['x'],
-                'y': location['y'],
-                'width': size['width'],
-                'height': size['height'],
-                'scale': self.parent.execute_script('return window.devicePixelRatio')
-            }
-        })
-        
-        self.parent.recover_screen()
+        viewport = {
+            'x': location['x'],
+            'y': location['y'],
+            'width': size['width'],
+            'height': size['height']
+        }
 
-        return response['data']
+        return self.parent.capture_viewport_as_base64(viewport, waiting_time)
 
 
     def __getitem__(self, attr):

--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -10,6 +10,7 @@ import re
 import sys
 import tempfile
 import time
+import base64
 from contextlib import contextmanager
 import warnings
 
@@ -599,7 +600,20 @@ class BaseWebDriver(DriverAPI):
     def uncheck(self, name):
         self.find_by_name(name).first.uncheck()
 
-    def screenshot(self, filename, full=False, waiting_time=0):
+    def screenshot(self, name="", suffix=".png", full=False):
+        warnings.warn('Deprecated, use `self.capture_screenshot()` instead.')
+
+        name = name or ""
+
+        (fd, filename) = tempfile.mkstemp(prefix=name, suffix=suffix)
+        # don't hold the file
+        os.close(fd)
+
+        self.capture_screenshot(filename, full)
+        
+        return filename
+
+    def capture_screenshot(self, filename, full=False, waiting_time=0):
         if full:
             self.full_screen()
             # trigger the `scroll` event to ensure lazy-load images can be rendered.
@@ -614,7 +628,7 @@ class BaseWebDriver(DriverAPI):
 
         return result
 
-    def screenshot_as_base64(self, full=False, waiting_time=0):
+    def capture_screenshot_as_base64(self, full=False, waiting_time=0):
         if full:
             self.full_screen()
             # trigger the `scroll` event to ensure lazy-load images can be rendered.
@@ -899,7 +913,21 @@ class WebDriverElement(ElementAPI):
         self.scroll_to()
         ActionChains(self.parent.driver).drag_and_drop(self._element, droppable._element).perform()
 
-    def screenshot(self, filename, waiting_time=0):
+    def screenshot(self, name='', suffix='.png', full=False):
+        warnings.warn('Deprecated, use `self.capture_screenshot()` instead.')
+
+        name = name or ''
+
+        (fd, filename) = tempfile.mkstemp(prefix=name, suffix=suffix)
+        # don't hold the file
+        os.close(fd)
+
+        self.capture_screenshot(filename)
+
+        return filename
+
+
+    def capture_screenshot(self, filename, waiting_time=0):
         base64_string = self.screenshot_as_base64(waiting_time)
         png = base64.b64decode(base64_string.encode('ascii'))
 
@@ -913,7 +941,7 @@ class WebDriverElement(ElementAPI):
 
         return True
 
-    def screenshot_as_base64(self, waiting_time=0):
+    def capture_screenshot_as_base64(self, waiting_time=0):
         self.parent.full_screen()
 
         if waiting_time > 0:

--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -635,6 +635,9 @@ class BaseWebDriver(DriverAPI):
     def capture_viewport_as_base64(self, viewport, waiting_time=0):
         self.full_screen()
 
+        # trigger the `scroll` event to ensure lazy-load images can be rendered.
+        self.execute_script("window.dispatchEvent(new Event('scroll'))")
+
         if waiting_time > 0: time.sleep(waiting_time)
 
         response = self.driver.execute_cdp_cmd('Page.captureScreenshot', {


### PR DESCRIPTION
Hey, thanks for the impressive works!!

I just found some issues, hopefully this can be merged 😆

## Solved

1. When using the [Emulation](https://sites.google.com/a/chromium.org/chromedriver/mobile-emulation), viewport won't get resized.
2. Can't get the correct full window size when element positioned using the `position: absolute;`.
3. Lazy-load images won't get loaded when capturing the full document.
4. The image scale won't change on higher pixel ratio device(window.devicePixelRatio > 1) when taking screenshot of an element. (I have reported the issue [here](https://bugs.chromium.org/p/chromedriver/issues/detail?id=3154))
5. Added `capture_viewport` & `capture_viewport_as_base64` methods

## Enhancement

1. Use the chrome-driver's [implementation](https://w3c.github.io/webdriver/#take-element-screenshot) to capture the element's screenshot.
2. Added `capture_screenshot_as_base64` method to both `BaseWebDriver` and `WebDriverElement`.
3. Added a parameter `waiting_time` for waiting images to be loaded.

## Breaking changes
Deprecated `screenshot` method, the new method name is `capture_screenshot`(signature changed).

I think we shouldn't force user to place the image to the temp directory. It's the user's responsibility to determine where the saved file should go 😀
(not yet fixed the test case and docs, if you are ok for this behavior I'll go to fix it.)

