### PR TITLE
Fixed dead external links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,15 +50,13 @@ Documentation
 
 External links
 ==============
-* `Django Full Stack Testing and BDD with Lettuce and Splinter <http://cilliano.com/blog/2011/02/07/django-bdd-with-lettuce-and-splinter/>`_
-
-* `Splinter: Python tool for acceptance tests on web applications <https://f.souza.cc/2011/05/splinter-python-tool-for-acceptance.html/>`_
+* `Django Full Stack Testing and BDD with Lettuce and Splinter <https://www.cilliano.com/2011/02/07/django-bdd-with-lettuce-and-splinter.html>`_
 
 * `Testes de aceitação com Lettuce e Splinter (pt-br) <http://www.slideshare.net/franciscosouza/testes-de-aceitao-com-lettuce-e-splinter?from=ss_embed>`_
 
 * `salad <https://github.com/salad/salad>`_, a nice mix of great BDD ingredients (splinter + `lettuce <http://lettuce.it>`_ integration)
 
-* `behave-django <https://github.com/mixxorz/behave-django>`_, BDD testing in Django using `Behave <http://pythonhosted.org/behave/>`_. Works well with splinter.
+* `behave-django <https://github.com/behave/behave-django>`_, BDD testing in Django using `Behave <https://github.com/behave/behave/>`_. Works well with splinter.
 
 * `pytest-splinter <http://pytest-splinter.readthedocs.io>`_, Splinter plugin for the `py.test <http://docs.pytest.org>`_ runner.
 

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -37,8 +37,7 @@ Projects using splinter
 Blog posts
 ----------
 
-* `Django Full Stack Testing and BDD with Lettuce and Splinter <http://cilliano.com/blog/2011/02/07/django-bdd-with-lettuce-and-splinter/>`_
-* `Splinter: Python tool for acceptance tests on web applications <http://f.souza.cc/2011/05/splinter-python-tool-for-acceptance-tests-on-web-applications/>`_
+* `Django Full Stack Testing and BDD with Lettuce and Splinter <https://www.cilliano.com/2011/02/07/django-bdd-with-lettuce-and-splinter.html>`_
 
 Slides and talks
 ----------------


### PR DESCRIPTION
Some of the external links had either moved to new addresses or just gone completely. Changed to the correct URLS and removed those who didn't exist anymore.