### PR TITLE
Accept all valid arguments for Remote WebDriver

### DIFF
--- a/docs/drivers/remote.rst
+++ b/docs/drivers/remote.rst
@@ -3,7 +3,7 @@
    license that can be found in the LICENSE file.
 
 .. meta::
-    :description: How to use splinter with Remote webdriver
+    :description: How to use splinter with Remote WebDriver
     :keywords: splinter, python, tutorial, how to install, installation, remote, selenium
 
 
@@ -11,8 +11,8 @@
 Remote WebDriver
 ++++++++++++++++
 
-Remote WebDriver is provided by Selenium2. To use it, you need to install
-Selenium2 via pip:
+Remote WebDriver is provided by Selenium. To use it, you need to install
+Selenium via pip:
 
 .. highlight:: bash
 
@@ -23,22 +23,24 @@ Selenium2 via pip:
 Setting up the Remote WebDriver
 -------------------------------
 
-To use the remote web driver, you need to have access to a Selenium remote
-webdriver server. Setting up one of these servers is beyond the scope of this
+To use Remote WebDriver, you need to have access to a Selenium remote
+WebDriver server. Setting up one of these servers is beyond the scope of this
 document. However, some companies provide access to a `Selenium Grid`_ as a service.
 
 
 Using the Remote WebDriver
 --------------------------
 
-To use the Remote WebDriver, you need to pass ``driver_name="remote"``
-and ``url=<remote server url>`` when you create the ``Browser`` instance.
+To use the Remote WebDriver, use ``driver_name="remote"`` when you create the ``Browser`` instance.
 
-You can also pass additional arguments that
-correspond to Selenium `DesiredCapabilities`_ arguments.
+The ``browser_name`` argument should then be used to specify the web browser.
+The other arguments match Selenium's `Remote WebDriver`_ arguments.
 
-Here is an example that uses `Sauce Labs`_ (a company that provides Selenium
-remote webdriver servers as a service) to request an Internet Explorer 9
+`Desired Capabilities`_ will be set automatically based on Selenium's defaults.
+These can be expanded and/or replaced by providing your own.
+
+The following example uses `Sauce Labs`_ (a company that provides Selenium
+Remote WebDriver servers as a service) to request an Internet Explorer 9
 browser instance running on Windows 7.
 
 .. highlight:: python
@@ -48,18 +50,24 @@ browser instance running on Windows 7.
     # Specify the server URL
     remote_server_url = 'http://YOUR_SAUCE_USERNAME:YOUR_SAUCE_ACCESS_KEY@ondemand.saucelabs.com:80/wd/hub'
 
-    with Browser(driver_name="remote",
-                 url=remote_server_url,
-                 browser='internetexplorer',
-                 platform="Windows 7",
-                 version="9",
-                 name="Test of IE 9 on WINDOWS") as browser:
+    with Browser(
+        driver_name="remote",
+        browser='internetexplorer',
+        command_executor=remote_server_url,
+        desired_capabilities = {
+          'platform': 'Windows 7',
+          'version': '9',
+          'name': 'Test of IE 9 on WINDOWS',
+        },
+        keep_alive=True,
+    ) as browser:
         print("Link to job: https://saucelabs.com/jobs/{}".format(
               browser.driver.session_id))
         browser.visit("https://splinter.readthedocs.io")
         browser.find_by_text('documentation').first.click()
 
 
-.. _Selenium Grid: https://code.google.com/p/selenium/wiki/Grid2
-.. _DesiredCapabilities: https://code.google.com/p/selenium/wiki/DesiredCapabilities
+.. _Desired Capabilities: https://selenium.dev/selenium/docs/api/py/webdriver/selenium.webdriver.common.desired_capabilities.html
+.. _Selenium Grid: https://selenium.dev/documentation/en/grid/
 .. _Sauce Labs: https://saucelabs.com
+.. _Remote WebDriver: https://selenium.dev/selenium/docs/api/py/webdriver_remote/selenium.webdriver.remote.webdriver.html

--- a/splinter/driver/webdriver/remote.py
+++ b/splinter/driver/webdriver/remote.py
@@ -33,12 +33,11 @@ class WebDriver(BaseWebDriver):
 
         # If no desired capabilities specified, add default ones
         caps = getattr(DesiredCapabilities, browser_name, {})
-        if not kwargs.get('desired_capabilities'):
-            kwargs['desired_capabilities'] = caps
-        else:
+        if kwargs.get('desired_capabilities'):
             # Combine user's desired capabilities with default
             caps.update(kwargs['desired_capabilities'])
-            kwargs['desired_capabilities'] = caps
+
+        kwargs['desired_capabilities'] = caps
 
         self.driver = Remote(command_executor, **kwargs)
 

--- a/splinter/driver/webdriver/remote.py
+++ b/splinter/driver/webdriver/remote.py
@@ -19,15 +19,28 @@ class WebDriver(BaseWebDriver):
     # TODO: This constant belongs in selenium.webdriver.Remote
     DEFAULT_URL = "http://127.0.0.1:4444/wd/hub"
 
-    def __init__(self, url=DEFAULT_URL, browser="firefox", wait_time=2, **ability_args):
-        browsername = browser.upper()
+    def __init__(
+        self,
+        browser="firefox",
+        wait_time=2,
+        command_executor=DEFAULT_URL,
+        **kwargs
+    ):
+        browser_name = browser.upper()
         # Handle case where user specifies IE with a space in it
-        if browsername == "INTERNET EXPLORER":
-            browsername = "INTERNETEXPLORER"
-        abilities = getattr(DesiredCapabilities, browsername, {})
-        abilities.update(ability_args)
+        if browser_name == "INTERNET EXPLORER":
+            browser_name = "INTERNETEXPLORER"
 
-        self.driver = Remote(url, abilities)
+        # If no desired capabilities specified, add default ones
+        caps = getattr(DesiredCapabilities, browser_name, {})
+        if not kwargs.get('desired_capabilities'):
+            kwargs['desired_capabilities'] = caps
+        else:
+            # Combine user's desired capabilities with default
+            caps.update(kwargs['desired_capabilities'])
+            kwargs['desired_capabilities'] = caps
+
+        self.driver = Remote(command_executor, **kwargs)
 
         self.element_class = WebDriverElement
 


### PR DESCRIPTION
This changes the Remote Browser from accepting desired capabilities in the keyword args to accepting anything and sending to Remote Webdriver as keyword args. As a result, desired capabilities are now sent as a dictionary instead of keyword args.

Documentation updated to reflect the new behaviour.