### PR TITLE
Refactor some chrome/firefox tests to use pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,11 @@ python:
   - "3.7"
   - "3.8-dev"
 env:
-  - DRIVER=tests/test_flaskclient.py
+  - DRIVER='tests/test_flaskclient.py tests/test_browser.py tests/test_element_list.py tests/test_request_handler.py'
+  - DRIVER=tests/test_webdriver.py
   - DRIVER=tests/test_webdriver_remote.py
   - DRIVER=tests/test_webdriver_firefox.py
   - DRIVER=tests/test_webdriver_chrome.py
-  - DRIVER=tests/test_browser.py
-  - DRIVER=tests/test_element_list.py
-  - DRIVER=tests/test_request_handler.py
 matrix:
   include:
     - python: 2.7

--- a/tests/test_webdriver.py
+++ b/tests/test_webdriver.py
@@ -1,0 +1,36 @@
+import os
+
+from .base import get_browser
+from .fake_webapp import EXAMPLE_APP
+
+import pytest
+
+
+supported_browsers = ['chrome', 'firefox']
+
+
+@pytest.mark.parametrize('browser_name', supported_browsers)
+def test_attach_file(request, browser_name):
+    """Should provide a way to change file field value"""
+    browser = get_browser(browser_name)
+    request.addfinalizer(browser.quit)
+
+    file_path = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "mockfile.txt"
+    )
+
+    browser.visit(EXAMPLE_APP)
+    browser.attach_file("file", file_path)
+    browser.find_by_name("upload").click()
+
+    html = browser.html
+    assert "text/plain" in html
+
+    with open(file_path, "r") as f:
+        assert str(f.read().encode("utf-8")) in html
+
+
+@pytest.mark.parametrize('browser_name', supported_browsers)
+def test_should_support_with_statement(browser_name):
+    with get_browser(browser_name):
+        pass

--- a/tests/test_webdriver_chrome.py
+++ b/tests/test_webdriver_chrome.py
@@ -4,70 +4,37 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-import os
 import unittest
 
 import pytest
 
 from .fake_webapp import EXAMPLE_APP
 from .base import WebDriverTests, get_browser
-from selenium.common.exceptions import WebDriverException
 
 
-def chrome_installed():
-    try:
-        Browser("chrome")
-    except WebDriverException:
-        return False
-    return True
-
-
-class ChromeBase(object):
-    @pytest.fixture(autouse=True, scope='class')
-    def teardown(self, request):
-        request.addfinalizer(self.browser.quit)
-
-
-class ChromeBrowserTest(WebDriverTests, ChromeBase, unittest.TestCase):
+class ChromeBrowserTest(WebDriverTests, unittest.TestCase):
     @pytest.fixture(autouse=True, scope='class')
     def setup_browser(self, request):
         request.cls.browser = get_browser('chrome', fullscreen=False)
+        request.addfinalizer(request.cls.browser.quit)
 
     @pytest.fixture(autouse=True)
     def visit_example_app(self, request):
         self.browser.driver.set_window_size(1024, 768)
         self.browser.visit(EXAMPLE_APP)
 
-    def test_attach_file(self):
-        "should provide a way to change file field value"
-        file_path = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)), "mockfile.txt"
-        )
-        self.browser.attach_file("file", file_path)
-        self.browser.find_by_name("upload").click()
 
-        html = self.browser.html
-        self.assertIn("text/plain", html)
-
-        with open(file_path) as f:
-            expected = str(f.read().encode("utf-8"))
-
-        self.assertIn(expected, html)
-
-    def test_should_support_with_statement(self):
-        with get_browser('chrome'):
-            pass
-
-
-class ChromeBrowserFullscreenTest(WebDriverTests, ChromeBase, unittest.TestCase):
+class ChromeBrowserFullscreenTest(WebDriverTests, unittest.TestCase):
     @pytest.fixture(autouse=True, scope='class')
     def setup_browser(self, request):
         request.cls.browser = get_browser('chrome', fullscreen=True)
+        request.addfinalizer(request.cls.browser.quit)
 
     @pytest.fixture(autouse=True)
     def visit_example_app(self):
         self.browser.visit(EXAMPLE_APP)
 
-    def test_should_support_with_statement(self):
-        with get_browser('chrome', fullscreen=True):
-            pass
+
+def test_should_support_with_statement_fullscreen():
+    with get_browser('chrome', fullscreen=True):
+        pass

--- a/tests/test_webdriver_firefox.py
+++ b/tests/test_webdriver_firefox.py
@@ -9,97 +9,61 @@ import unittest
 
 import pytest
 
-from splinter import Browser
 from .fake_webapp import EXAMPLE_APP
 from .base import WebDriverTests, get_browser
 
 
-def firefox_installed():
-    try:
-        Browser("firefox")
-    except OSError:
-        return False
-    return True
-
-
-class FirefoxBase(object):
-    @pytest.fixture(autouse=True, scope='class')
-    def teardown(self, request):
-        request.addfinalizer(self.browser.quit)
-
-
-class FirefoxBrowserTest(WebDriverTests, FirefoxBase, unittest.TestCase):
+class FirefoxBrowserTest(WebDriverTests, unittest.TestCase):
     @pytest.fixture(autouse=True, scope='class')
     def setup_browser(self, request):
         request.cls.browser = get_browser('firefox', fullscreen=False)
+        request.addfinalizer(request.cls.browser.quit)
 
     @pytest.fixture(autouse=True)
     def visit_example_app(self, request):
         self.browser.visit(EXAMPLE_APP)
 
-    def test_attach_file(self):
-        "should provide a way to change file field value"
-        file_path = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)), "mockfile.txt"
-        )
-        self.browser.attach_file("file", file_path)
-        self.browser.find_by_name("upload").click()
 
-        html = self.browser.html
-        self.assertIn("text/plain", html)
-        self.assertIn(open(file_path, "rb").read().decode("utf-8"), html)
-
-    def test_should_support_with_statement(self):
-        with Browser("firefox", headless=True):
-            pass
-
-
-class FirefoxWithExtensionTest(FirefoxBase, unittest.TestCase):
-    @pytest.fixture(autouse=True, scope='class')
-    def setup_browser(self, request):
-        extension_path = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)), "firebug.xpi"
-        )
-
-        request.cls.browser = get_browser('firefox', extensions=[extension_path])
-
-    def test_create_a_firefox_instance_with_extension(self):
-        "should be able to load an extension"
-        self.assertIn(
-            "firebug@software.joehewitt.com",
-            os.listdir(self.browser.driver.profile.extensionsDir),
-        )
-
-
-class FirefoxBrowserProfilePreferencesTest(FirefoxBase, unittest.TestCase):
-    @pytest.fixture(autouse=True, scope='class')
-    def setup_browser(self, request):
-        preferences = {
-            "dom.max_script_run_time": 360,
-            "devtools.inspector.enabled": True,
-        }
-
-        request.cls.browser = get_browser('firefox', profile_preferences=preferences)
-
-    def test_preference_set(self):
-        preferences = self.browser.driver.profile.default_preferences
-        self.assertIn("dom.max_script_run_time", preferences)
-        value = preferences.get("dom.max_script_run_time")
-        self.assertEqual(int(value), 360)
-
-
-class FirefoxBrowserCapabilitiesTest(FirefoxBase, unittest.TestCase):
-    @pytest.fixture(autouse=True, scope='class')
-    def setup_browser(self, request):
-        request.cls.browser = get_browser('firefox', capabilities={"pageLoadStrategy": "eager"})
-
-    def test_capabilities_set(self):
-        capabilities = self.browser.driver.capabilities
-        self.assertIn("pageLoadStrategy", capabilities)
-        self.assertEqual("eager", capabilities.get("pageLoadStrategy"))
-
-
-class FirefoxBrowserFullScreenTest(FirefoxBase, unittest.TestCase):
+class FirefoxBrowserFullScreenTest(WebDriverTests, unittest.TestCase):
     @pytest.fixture(autouse=True, scope='class')
     def setup_browser(self, request):
         request.cls.browser = get_browser('firefox', fullscreen=True)
+        request.addfinalizer(request.cls.browser.quit)
+
+    @pytest.fixture(autouse=True)
+    def visit_example_app(self):
+        self.browser.visit(EXAMPLE_APP)
+
+
+def test_create_a_firefox_instance_with_extension(request):
+    extension_path = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "firebug.xpi"
+    )
+    browser = get_browser('firefox', extensions=[extension_path])
+    request.addfinalizer(browser.quit)
+    "should be able to load an extension"
+    assert "firebug@software.joehewitt.com" in os.listdir(browser.driver.profile.extensionsDir)
+
+
+def test_preference_set(request):
+    preferences = {
+        "dom.max_script_run_time": 360,
+        "devtools.inspector.enabled": True,
+    }
+    browser = get_browser('firefox', profile_preferences=preferences)
+    request.addfinalizer(browser.quit)
+
+    preferences = browser.driver.profile.default_preferences
+    assert "dom.max_script_run_time" in preferences
+
+    value = preferences.get("dom.max_script_run_time")
+    assert int(value) == 360
+
+
+def test_capabilities_set(request):
+    browser = get_browser('firefox', capabilities={"pageLoadStrategy": "eager"})
+    request.addfinalizer(browser.quit)
+
+    capabilities = browser.driver.capabilities
+    assert "pageLoadStrategy" in capabilities
+    assert "eager" == capabilities.get("pageLoadStrategy")

--- a/tests/test_webdriver_remote.py
+++ b/tests/test_webdriver_remote.py
@@ -14,6 +14,8 @@ from splinter import Browser
 from .fake_webapp import EXAMPLE_APP
 from .base import WebDriverTests
 
+import pytest
+
 
 def selenium_server_is_running():
     try:
@@ -26,13 +28,10 @@ def selenium_server_is_running():
 
 
 class RemoteBrowserTest(WebDriverTests, unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.browser = Browser("remote")
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.browser.quit()
+    @pytest.fixture(autouse=True, scope='class')
+    def setup_browser(self, request):
+        request.cls.browser = Browser("remote")
+        request.addfinalizer(request.cls.browser.quit)
 
     def setUp(self):
         self.browser.visit(EXAMPLE_APP)

--- a/travis-install.bash
+++ b/travis-install.bash
@@ -18,9 +18,10 @@ if [ "${DRIVER}" = "tests/test_webdriver_remote.py" ]; then
 	sleep 1
 fi
 
-if [ "${DRIVER}" = "tests/test_webdriver_chrome.py" ]; then
+if [ "${DRIVER}" = "tests/test_webdriver_chrome.py" ] || [ "${DRIVER}" = "tests/test_webdriver.py" ]; then
     sleep 1
 
     FILE=`mktemp`; wget "https://chromedriver.storage.googleapis.com/2.42/chromedriver_linux64.zip" -qO $FILE && unzip $FILE chromedriver -d ~; rm $FILE; chmod 777 ~/chromedriver;
     export PATH=$HOME:$PATH
 fi
+


### PR DESCRIPTION
This PR reduces some code duplication by using pytest's parametrize feature, as opposed to placing tests in classes.

Some tests have been rewritten slightly to use pytest, and test_flaskclient.py, test_browser.py test_element_list.py, and test_request_handler.py have been combined into one job on travis-CI.