### PR TITLE
Allow ActionChains when using Remote WebDriver

### DIFF
--- a/splinter/driver/webdriver/remote.py
+++ b/splinter/driver/webdriver/remote.py
@@ -8,7 +8,7 @@ from selenium.webdriver import Remote
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from splinter.driver.webdriver import (
     BaseWebDriver,
-    WebDriverElement as BaseWebDriverElement,
+    WebDriverElement,
 )
 from splinter.driver.webdriver.cookie_manager import CookieManager
 
@@ -46,38 +46,3 @@ class WebDriver(BaseWebDriver):
         self._cookie_manager = CookieManager(self.driver)
 
         super(WebDriver, self).__init__(wait_time)
-
-
-class WebDriverElement(BaseWebDriverElement):
-    def mouse_over(self):
-        """
-        Remote Firefox doesn't support mouseover.
-        """
-        raise NotImplementedError("Remote Firefox doesn't support mouse over")
-
-    def mouse_out(self):
-        """
-        Remote Firefox doesn't support mouseout.
-        """
-        raise NotImplementedError("Remote Firefox doesn't support mouseout")
-
-    def double_click(self):
-        """
-        Remote Firefox doesn't support doubleclick.
-        """
-        raise NotImplementedError("Remote Firefox doesn't support doubleclick")
-
-    def right_click(self):
-        """
-        Remote Firefox doesn't support right click'
-        """
-        raise NotImplementedError("Remote Firefox doesn't support right click")
-
-    def drag_and_drop(self, droppable):
-        """
-        Remote Firefox doesn't support drag and drop
-        """
-        raise NotImplementedError("Remote Firefox doesn't support drag an drop")
-
-    mouseover = mouse_over
-    mouseout = mouse_out

--- a/tests/test_webdriver_remote.py
+++ b/tests/test_webdriver_remote.py
@@ -42,42 +42,6 @@ class RemoteBrowserTest(WebDriverTests, unittest.TestCase):
         with Browser("remote"):
             pass
 
-    def test_mouse_over(self):
-        "Remote should not support mouseover"
-        with self.assertRaises(NotImplementedError):
-            self.browser.find_by_id("visible").mouse_over()
-
-    def test_mouse_out(self):
-        "Remote should not support mouseout"
-        with self.assertRaises(NotImplementedError):
-            self.browser.find_by_id("visible").mouse_out()
-
-    def test_mouse_out_top_left(self):
-        "Remote should not support mouseout"
-        with self.assertRaises(NotImplementedError):
-            self.browser.find_by_id("visible").mouse_out()
-
-    def test_double_click(self):
-        "Remote should not support double_click"
-        with self.assertRaises(NotImplementedError):
-            self.browser.find_by_id("visible").double_click()
-
-    def test_right_click(self):
-        "Remote should not support right_click"
-        with self.assertRaises(NotImplementedError):
-            self.browser.find_by_id("visible").right_click()
-
-    def test_drag_and_drop(self):
-        "Remote should not support drag_and_drop"
-        with self.assertRaises(NotImplementedError):
-            droppable = self.browser.find_by_css(".droppable")
-            self.browser.find_by_css(".draggable").drag_and_drop(droppable)
-
-    def test_mouseover_should_be_an_alias_to_mouse_over(self):
-        "Remote should not support mouseover"
-        with self.assertRaises(NotImplementedError):
-            self.browser.find_by_id("visible").mouseover()
-
     def test_should_be_able_to_change_user_agent(self):
         "Remote should not support custom user agent"
         pass

--- a/travis-install.bash
+++ b/travis-install.bash
@@ -13,7 +13,7 @@ fi
 if [ "${DRIVER}" = "tests/test_webdriver_remote.py" ]; then
   sleep 1
 
-  wget https://goo.gl/s4o9Vx -O selenium-server.jar
+  wget https://selenium-release.storage.googleapis.com/3.10/selenium-server-standalone-3.10.0.jar -O selenium-server.jar
 	java -jar selenium-server.jar > /dev/null 2>&1 &
 	sleep 1
 fi


### PR DESCRIPTION
Newer versions of Remote Firefox support ActionChains.

This also deals with most of #674.

However, there's still no specific test configuration for Remote Chrome.