### PR TITLE
Standardize CookieManager and accept all valid cookie arguments

### DIFF
--- a/docs/cookies.rst
+++ b/docs/cookies.rst
@@ -23,7 +23,7 @@ To add a cookie use the add method:
 
 ::
 
-    browser.cookies.add({'whatever': 'and ever'})
+    browser.cookies.add('cookie name', 'cookie value')
 
 Retrieve all cookies
 --------------------

--- a/splinter/cookie_manager.py
+++ b/splinter/cookie_manager.py
@@ -22,16 +22,27 @@ class CookieManagerAPI(InheritedDocs("_CookieManagerAPI", (object,), {})):
         >>> assert cookie_manager['name'] == 'Tony'
     """
 
-    def add(self, cookies):
-        """
-        Adds a cookie.
+    def __init__(self, driver):
+        self.driver = driver
 
-        The ``cookie`` parameter is a ``dict`` where each key is an identifier
-        for the cookie value (like any ``dict``).
+    def add(self, key, value='', max_age=None, expires=None, path='/',
+            domain=None, secure=False, httponly=False, samesite=None):
+        """Add a cookie.
+
+        Arguments:
+            key: Cookie name
+            value: Cookie value
+            expires
+            path
+            domain
+            max_age
+            secure
+            httponly
+            samesite
 
         Example of use:
 
-            >>> cookie_manager.add({'name': 'Tony'})
+            >>> cookie_manager.add('name', 'Tony')
         """
         raise NotImplementedError
 
@@ -48,6 +59,12 @@ class CookieManagerAPI(InheritedDocs("_CookieManagerAPI", (object,), {})):
             >>> cookie_manager.delete('name', 'birthday',
                                       'favorite_color') # deletes these three cookies
             >>> cookie_manager.delete('name') # deletes one cookie
+        """
+        raise NotImplementedError
+
+    def delete_all(self):
+        """
+        Delete all cookies.
         """
         raise NotImplementedError
 

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -4,8 +4,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from __future__ import with_statement
-
 try:
     from urllib.parse import parse_qs, urlparse, urlencode, urlunparse
 except:
@@ -19,47 +17,49 @@ from .lxmldriver import LxmlDriver
 
 
 class CookieManager(CookieManagerAPI):
-    def __init__(self, browser_cookies):
-        self._cookies = browser_cookies
-
-    def add(self, cookies):
-        if isinstance(cookies, list):
-            for cookie in cookies:
-                for key, value in cookie.items():
-                    self._cookies.set_cookie("localhost", key, value)
-                return
-        for key, value in cookies.items():
-            self._cookies.set_cookie("localhost", key, value)
+    def add(self, key, value='', max_age=None, expires=None, path='/',
+            domain=None, secure=False, httponly=False, samesite=None):
+        self.driver.set_cookie(
+            'localhost',
+            key,
+            value=value,
+            max_age=max_age,
+            expires=expires,
+            path=path,
+            domain=domain,
+            secure=secure,
+            httponly=httponly,
+        )
 
     def delete(self, *cookies):
         if cookies:
             for cookie in cookies:
-                try:
-                    self._cookies.delete_cookie("localhost", cookie)
-                except KeyError:
-                    pass
+                self.driver.delete_cookie('localhost', cookie)
         else:
-            self._cookies.cookie_jar.clear()
+            self.delete_all()
+
+    def delete_all(self):
+        self.driver.cookie_jar.clear()
 
     def all(self, verbose=False):
         cookies = {}
-        for cookie in self._cookies.cookie_jar:
+        for cookie in self.driver.cookie_jar:
             cookies[cookie.name] = cookie.value
         return cookies
 
     def __getitem__(self, item):
-        cookies = dict([(c.name, c) for c in self._cookies.cookie_jar])
+        cookies = dict([(c.name, c) for c in self.driver.cookie_jar])
         return cookies[item].value
 
     def __contains__(self, key):
-        for cookie in self._cookies.cookie_jar:
+        for cookie in self.driver.cookie_jar:
             if cookie.name == key:
                 return True
         return False
 
     def __eq__(self, other_object):
         if isinstance(other_object, dict):
-            cookies_dict = dict([(c.name, c.value) for c in self._cookies.cookie_jar])
+            cookies_dict = dict([(c.name, c.value) for c in self.driver.cookie_jar])
             return cookies_dict == other_object
         return False
 

--- a/splinter/driver/lxmldriver.py
+++ b/splinter/driver/lxmldriver.py
@@ -4,7 +4,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from __future__ import with_statement
 import os.path
 import re
 import time

--- a/splinter/driver/webdriver/cookie_manager.py
+++ b/splinter/driver/webdriver/cookie_manager.py
@@ -14,24 +14,29 @@ else:
 
 
 class CookieManager(CookieManagerAPI):
-    def __init__(self, driver):
-        self.driver = driver
-
-    def add(self, cookies):
-        if isinstance(cookies, list):
-            for cookie in cookies:
-                for key, value in cookie.items():
-                    self.driver.add_cookie({"name": key, "value": value})
-                return
-        for key, value in cookies.items():
-            self.driver.add_cookie({"name": key, "value": value})
+    def add(self, key, value='', max_age=None, expires=None, path='/',
+            domain=None, secure=False, httponly=False, samesite=None):
+        self.driver.add_cookie(
+            {
+                'name': key,
+                'value': value,
+                'path': path,
+                'domain': domain,
+                'secure': secure,
+                'expiry': expires,
+                'httpOnly': httponly,
+            }
+        )
 
     def delete(self, *cookies):
         if cookies:
             for cookie in cookies:
                 self.driver.delete_cookie(cookie)
         else:
-            self.driver.delete_all_cookies()
+            self.delete_all()
+
+    def delete_all(self):
+        self.driver.delete_all_cookies()
 
     def all(self, verbose=False):
         if not verbose:

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -21,17 +21,16 @@ import time
 
 
 class CookieManager(CookieManagerAPI):
-    def __init__(self, driver):
-        self.driver = driver
-
-    def add(self, cookies):
-        if isinstance(cookies, list):
-            for cookie in cookies:
-                for key, value in cookie.items():
-                    self.driver.cookies[key] = value
-                return
-        for key, value in cookies.items():
-            self.driver.cookies[key] = value
+    def add(self, key, value='', max_age=None, expires=None, path='/',
+            domain=None, secure=False, httponly=False, samesite=None):
+        self.driver.cookies.create(
+            key,
+            value=value,
+            domain=domain,
+            expires=expires,
+            path=path,
+            secure=secure,
+        )
 
     def delete(self, *cookies):
         if cookies:
@@ -41,7 +40,10 @@ class CookieManager(CookieManagerAPI):
                 except KeyError:
                     pass
         else:
-            self.driver.cookies.clearAll()
+            self.delete_all()
+
+    def delete_all(self):
+        self.driver.cookies.clearAll()
 
     def all(self, verbose=False):
         cookies = {}

--- a/tests/cookies.py
+++ b/tests/cookies.py
@@ -7,65 +7,50 @@
 
 class CookiesTest(object):
     def test_create_and_access_a_cookie(self):
-        "should be able to create and access a cookie"
-        self.browser.cookies.add({"sha": "zam"})
+        """should be able to create and access a cookie"""
+        self.browser.cookies.add("sha", "zam")
         self.assertEqual(self.browser.cookies["sha"], "zam")
-
-    def test_create_many_cookies_at_once_as_dict(self):
-        "should be able to create many cookies at once as dict"
-        cookies = {"sha": "zam", "foo": "bar"}
-        self.browser.cookies.add(cookies)
-        self.assertEqual(self.browser.cookies["sha"], "zam")
-        self.assertEqual(self.browser.cookies["foo"], "bar")
-
-    def test_create_many_cookies_at_once_as_list(self):
-        "should be able to create many cookies at once as list"
-        cookies = [{"sha": "zam"}, {"foo": "bar"}]
-        self.browser.cookies.add(cookies)
-        self.assertEqual(self.browser.cookies["sha"], "zam")
-        self.assertEqual(self.browser.cookies["foo"], "bar")
 
     def test_create_some_cookies_and_delete_them_all(self):
-        "should be able to delete all cookies"
-        self.browser.cookies.add({"whatever": "and ever"})
-        self.browser.cookies.add({"anothercookie": "im bored"})
+        """should be able to delete all cookies"""
+        self.browser.cookies.add("whatever", "and ever")
+        self.browser.cookies.add("anothercookie", "im bored")
         self.browser.cookies.delete()
         self.assertEqual(self.browser.cookies, {})
 
     def test_create_and_delete_a_cookie(self):
-        "should be able to create and destroy a cookie"
+        """should be able to create and destroy a cookie"""
         self.browser.cookies.delete()
-        self.browser.cookies.add({"cookie": "with milk"})
+        self.browser.cookies.add("cookie", "with milk")
         self.browser.cookies.delete("cookie")
         self.assertEqual(self.browser.cookies, {})
 
     def test_create_and_delete_many_cookies(self):
-        "should be able to create and destroy many cookies"
+        """should be able to create and destroy many cookies"""
         self.browser.cookies.delete()
-        self.browser.cookies.add({"acookie": "cooked"})
-        self.browser.cookies.add({"anothercookie": "uncooked"})
-        self.browser.cookies.add({"notacookie": "halfcooked"})
+        self.browser.cookies.add("acookie", "cooked")
+        self.browser.cookies.add("anothercookie", "uncooked")
+        self.browser.cookies.add("notacookie", "halfcooked")
         self.browser.cookies.delete("acookie", "notacookie")
         self.assertEqual("uncooked", self.browser.cookies["anothercookie"])
 
     def test_try_to_destroy_an_absent_cookie_and_nothing_happens(self):
         self.browser.cookies.delete()
-        self.browser.cookies.add({"foo": "bar"})
+        self.browser.cookies.add("foo", "bar")
         self.browser.cookies.delete("mwahahahaha")
         self.assertEqual(self.browser.cookies, {"foo": "bar"})
 
     def test_create_and_get_all_cookies(self):
-        "should be able to create some cookies and retrieve them all"
+        """should be able to create some cookies and retrieve them all"""
         self.browser.cookies.delete()
-        self.browser.cookies.add({"taco": "shrimp"})
-        self.browser.cookies.add({"lavar": "burton"})
+        self.browser.cookies.add("taco", "shrimp")
+        self.browser.cookies.add("lavar", "burton")
         self.assertEqual(len(self.browser.cookies.all()), 2)
         self.browser.cookies.delete()
         self.assertEqual(self.browser.cookies.all(), {})
 
     def test_create_and_use_contains(self):
-        "should be able to create many cookies at once as dict"
-        cookies = {"sha": "zam"}
-        self.browser.cookies.add(cookies)
+        """should be able to create many cookies at once as dict"""
+        self.browser.cookies.add('sha', 'zam')
         self.assertIn("sha", self.browser.cookies)
         self.assertNotIn("foo", self.browser.cookies)


### PR DESCRIPTION
- Add CookieManager.delete_all() method
- Standardize the init phase for CookieManager subclasses
- Remove ability to send a list to CookieManager.add(). This was undocumented and having an argument that takes multiple types seems like a bad idea.
- Rewrite CookieManager.add() to accept arguments for cookie parameters instead of a dict with a key/value for name and value parameters.

The change to CookieManager.add() is incompatible with the current function signature, unfortunately.

Note that flask does not use the samesite parameter, and zope does not use httponly and samesite parameters.

Fixes #307, #388, and probably #743, but it needs to be tested.

