### PR TITLE
Added retry_count to get_driver

### DIFF
--- a/splinter/browser.py
+++ b/splinter/browser.py
@@ -89,4 +89,4 @@ def Browser(driver_name="firefox", retry_count=3, *args, **kwargs):
     except KeyError:
         raise DriverNotFoundError("No driver for %s" % driver_name)
 
-    return get_driver(driver, *args, **kwargs)
+    return get_driver(driver, retry_count=retry_count, *args, **kwargs)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -72,3 +72,29 @@ def test_local_driver_not_present(browser_name):
         Browser(browser_name, executable_path='failpath')
 
     assert "Message: 'failpath' executable needs to be in PATH." in str(e.value)
+
+
+def test_driver_retry_count():
+    """Checks that the retry count is being used"""
+    from splinter.browser import _DRIVERS
+    from splinter import Browser
+    global test_retry_count
+
+    def test_driver(*args, **kwargs):
+        global test_retry_count
+        test_retry_count += 1
+        raise IOError("test_retry_count: " + str(test_retry_count))
+    _DRIVERS["test_driver"] = test_driver
+
+    test_retry_count = 0
+    with pytest.raises(IOError) as e:
+        Browser("test_driver")
+    assert "test_retry_count: 3" == str(e.value)
+
+    test_retry_count = 0
+    with pytest.raises(OSError) as e:
+        Browser('test_driver', retry_count=10)
+    assert "test_retry_count: 10" == str(e.value)
+
+    del test_retry_count
+    del _DRIVERS['test_driver']

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -92,9 +92,9 @@ def test_driver_retry_count():
     assert "test_retry_count: 3" == str(e.value)
 
     test_retry_count = 0
-    with pytest.raises(OSError) as e:
-        Browser('test_driver', retry_count=10)
+    with pytest.raises(IOError) as e:
+        Browser("test_driver", retry_count=10)
     assert "test_retry_count: 10" == str(e.value)
 
     del test_retry_count
-    del _DRIVERS['test_driver']
+    del _DRIVERS["test_driver"]


### PR DESCRIPTION
It looks like Browser is taking `retry_count` as an argument
which is never used. Fixed by adding it to get_driver.