### PR TITLE
Standardize CookieManager and accept all valid cookie arguments

### DIFF
--- a/docs/cookies.rst
+++ b/docs/cookies.rst
@@ -7,25 +7,35 @@
     :keywords: splinter, python, tutorial, documentation, cookies
 
 ++++++++++++++++++++
-Cookies manipulation
+Cookies Manipulation
 ++++++++++++++++++++
 
 It is possible to manipulate cookies using the `cookies` attribute from a
 `Browser` instance. The `cookies` attribute is a instance of a `CookieManager`
-class that manipulates cookies, like adding and deleting them.
+class that manipulates cookies (ie: adding and deleting them).
 
-Create cookie
+Create Cookie
 -------------
 
-To add a cookie use the add method:
+To add a cookie use the browser.cookies.add method:
 
 .. highlight:: python
 
 ::
 
-    browser.cookies.add({'whatever': 'and ever'})
+    browser.cookies.add('cookie name', 'cookie value')
 
-Retrieve all cookies
+Extra Arguments
+~~~~~~~~~~~~~~~
+
+Each driver accepts various parameters when creating cookies.
+These can be used with browser.cookies.add as extra arguments.
+For example, WebDriver can use `path`, `domain`, `secure`, and `expiry`:
+
+::
+    browser.cookies.add('cookie_name', 'cookie_value', path='/cookiePath')
+
+Retrieve All Cookies
 --------------------
 
 To retrieve all cookies use the `all` method:

--- a/splinter/cookie_manager.py
+++ b/splinter/cookie_manager.py
@@ -18,20 +18,27 @@ class CookieManagerAPI(InheritedDocs("_CookieManagerAPI", (object,), {})):
     A CookieManager acts like a ``dict``, so you can access the value of a
     cookie through the [] operator, passing the cookie identifier:
 
-        >>> cookie_manager.add({'name': 'Tony'})
+        >>> cookie_manager.add('name', 'Tony')
         >>> assert cookie_manager['name'] == 'Tony'
     """
 
-    def add(self, cookies):
-        """
-        Adds a cookie.
+    def __init__(self, driver):
+        self.driver = driver
 
-        The ``cookie`` parameter is a ``dict`` where each key is an identifier
-        for the cookie value (like any ``dict``).
+    def add(self, key, value='', **kwargs):
+        """Add a cookie.
 
-        Example of use:
+        Arguments:
+            key: Cookie name
+            value: Cookie value
+            kwargs: Parameters to set in the cookie. Valid parameters depend
+                on the Driver.
 
-            >>> cookie_manager.add({'name': 'Tony'})
+        Examples:
+
+            >>> cookie_manager.add('name', 'Tony')
+
+            >>> cookie_manager.add('name', 'Tony', secure=True)
         """
         raise NotImplementedError
 
@@ -51,6 +58,12 @@ class CookieManagerAPI(InheritedDocs("_CookieManagerAPI", (object,), {})):
         """
         raise NotImplementedError
 
+    def delete_all(self):
+        """
+        Delete all cookies.
+        """
+        raise NotImplementedError
+
     def all(self, verbose=False):
         """
         Returns all of the cookies.
@@ -62,7 +75,7 @@ class CookieManagerAPI(InheritedDocs("_CookieManagerAPI", (object,), {})):
 
         Examples:
 
-            >>> cookie_manager.add({'name': 'Tony'})
+            >>> cookie_manager.add('name', 'Tony')
             >>> cookie_manager.all()
             [{'name': 'Tony'}]
         """

--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -4,7 +4,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from __future__ import with_statement
 import six
 from six.moves.urllib import parse
 
@@ -15,44 +14,40 @@ from .lxmldriver import LxmlDriver
 
 
 class CookieManager(CookieManagerAPI):
-    def __init__(self, browser_cookies):
-        self._cookies = browser_cookies
-
-    def add(self, cookies):
-        if isinstance(cookies, list):
-            for cookie in cookies:
-                for key, value in cookie.items():
-                    self._cookies[key] = value
-                return
-        for key, value in cookies.items():
-            self._cookies[key] = value
+    def add(self, key, value='', **kwargs):
+        self.driver.cookies[key] = value
+        for k, v in kwargs.items():
+            self.driver.cookies[key][k] = v
 
     def delete(self, *cookies):
         if cookies:
             for cookie in cookies:
                 try:
-                    del self._cookies[cookie]
+                    del self.driver.cookies[cookie]
                 except KeyError:
                     pass
         else:
-            self._cookies.clear()
+            self.delete_all()
+
+    def delete_all(self):
+        self.driver.cookies.clear()
 
     def all(self, verbose=False):
         cookies = {}
-        for key, value in self._cookies.items():
+        for key, value in self.driver.cookies.items():
             cookies[key] = value
         return cookies
 
     def __getitem__(self, item):
-        return self._cookies[item].value
+        return self.driver.cookies[item]
 
     def __contains__(self, key):
-        return key in self._cookies
+        return key in self.driver.cookies
 
     def __eq__(self, other_object):
         if isinstance(other_object, dict):
             cookies_dict = dict(
-                [(key, morsel.value) for key, morsel in self._cookies.items()]
+                [(key, morsel.value) for key, morsel in self.driver.cookies.items()]
             )
             return cookies_dict == other_object
         return False
@@ -74,7 +69,7 @@ class DjangoClient(LxmlDriver):
 
         self._browser = Client(**client_kwargs)
         self._user_agent = user_agent
-        self._cookie_manager = CookieManager(self._browser.cookies)
+        self._cookie_manager = CookieManager(self._browser)
         super(DjangoClient, self).__init__(wait_time=wait_time)
 
     def __enter__(self):

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -4,8 +4,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from __future__ import with_statement
-
 try:
     from urllib.parse import parse_qs, urlparse, urlencode, urlunparse
 except:
@@ -19,47 +17,42 @@ from .lxmldriver import LxmlDriver
 
 
 class CookieManager(CookieManagerAPI):
-    def __init__(self, browser_cookies):
-        self._cookies = browser_cookies
+    def add(self, key, value='', **kwargs):
+        kwargs['server_name'] = 'localhost'
+        kwargs['key'] = key
+        kwargs['value'] = value
 
-    def add(self, cookies):
-        if isinstance(cookies, list):
-            for cookie in cookies:
-                for key, value in cookie.items():
-                    self._cookies.set_cookie("localhost", key, value)
-                return
-        for key, value in cookies.items():
-            self._cookies.set_cookie("localhost", key, value)
+        self.driver.set_cookie(**kwargs)
 
     def delete(self, *cookies):
         if cookies:
             for cookie in cookies:
-                try:
-                    self._cookies.delete_cookie("localhost", cookie)
-                except KeyError:
-                    pass
+                self.driver.delete_cookie('localhost', cookie)
         else:
-            self._cookies.cookie_jar.clear()
+            self.delete_all()
+
+    def delete_all(self):
+        self.driver.cookie_jar.clear()
 
     def all(self, verbose=False):
         cookies = {}
-        for cookie in self._cookies.cookie_jar:
-            cookies[cookie.name] = cookie.value
+        for cookie in self.driver.cookie_jar:
+            cookies[cookie.name] = cookie
         return cookies
 
     def __getitem__(self, item):
-        cookies = dict([(c.name, c) for c in self._cookies.cookie_jar])
-        return cookies[item].value
+        cookies = dict([(c.name, c) for c in self.driver.cookie_jar])
+        return cookies[item]
 
     def __contains__(self, key):
-        for cookie in self._cookies.cookie_jar:
+        for cookie in self.driver.cookie_jar:
             if cookie.name == key:
                 return True
         return False
 
     def __eq__(self, other_object):
         if isinstance(other_object, dict):
-            cookies_dict = dict([(c.name, c.value) for c in self._cookies.cookie_jar])
+            cookies_dict = dict([(c.name, c.value) for c in self.driver.cookie_jar])
             return cookies_dict == other_object
         return False
 

--- a/splinter/driver/lxmldriver.py
+++ b/splinter/driver/lxmldriver.py
@@ -4,7 +4,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from __future__ import with_statement
 import os.path
 import re
 import time

--- a/splinter/driver/webdriver/cookie_manager.py
+++ b/splinter/driver/webdriver/cookie_manager.py
@@ -14,29 +14,29 @@ else:
 
 
 class CookieManager(CookieManagerAPI):
-    def __init__(self, driver):
-        self.driver = driver
+    def add(self, key, value='', **kwargs):
+        cookie = {
+            'name': key,
+            'value': value,
+        }
+        cookie.update(kwargs)
 
-    def add(self, cookies):
-        if isinstance(cookies, list):
-            for cookie in cookies:
-                for key, value in cookie.items():
-                    self.driver.add_cookie({"name": key, "value": value})
-                return
-        for key, value in cookies.items():
-            self.driver.add_cookie({"name": key, "value": value})
+        self.driver.add_cookie(cookie)
 
     def delete(self, *cookies):
         if cookies:
             for cookie in cookies:
                 self.driver.delete_cookie(cookie)
         else:
-            self.driver.delete_all_cookies()
+            self.delete_all()
+
+    def delete_all(self):
+        self.driver.delete_all_cookies()
 
     def all(self, verbose=False):
+        cookies = self.driver.get_cookies()
         if not verbose:
             cleaned_cookies = {}
-            cookies = self.driver.get_cookies()
             for cookie in cookies:
                 if not cookie["domain"].startswith("."):
                     cookie_domain = cookie["domain"]
@@ -44,13 +44,14 @@ class CookieManager(CookieManagerAPI):
                     cookie_domain = cookie["domain"][1:]
 
                 if cookie_domain in urlparse(self.driver.current_url).netloc:
-                    cleaned_cookies[cookie["name"]] = cookie["value"]
+                    cleaned_cookies[cookie["name"]] = cookie
 
             return cleaned_cookies
-        return self.driver.get_cookies()
+
+        return cookies
 
     def __getitem__(self, item):
-        return self.driver.get_cookie(item)["value"]
+        return self.driver.get_cookie(item)
 
     def __contains__(self, key):
         return self.driver.get_cookie(key) is not None

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -21,17 +21,13 @@ import time
 
 
 class CookieManager(CookieManagerAPI):
-    def __init__(self, driver):
-        self.driver = driver
-
-    def add(self, cookies):
-        if isinstance(cookies, list):
-            for cookie in cookies:
-                for key, value in cookie.items():
-                    self.driver.cookies[key] = value
-                return
-        for key, value in cookies.items():
-            self.driver.cookies[key] = value
+    def add(self, key, value='', **kwargs):
+        kwargs['name'] = key
+        kwargs['value'] = value
+        if key not in self.driver.cookies:
+            self.driver.cookies.create(**kwargs)
+        else:
+            self.driver.cookies.change(**kwargs)
 
     def delete(self, *cookies):
         if cookies:
@@ -41,7 +37,10 @@ class CookieManager(CookieManagerAPI):
                 except KeyError:
                     pass
         else:
-            self.driver.cookies.clearAll()
+            self.delete_all()
+
+    def delete_all(self):
+        self.driver.cookies.clearAll()
 
     def all(self, verbose=False):
         cookies = {}
@@ -50,7 +49,7 @@ class CookieManager(CookieManagerAPI):
         return cookies
 
     def __getitem__(self, item):
-        return self.driver.cookies[item]
+        return self.driver.cookies.getinfo(item)
 
     def __contains__(self, key):
         return key in self.driver.cookies

--- a/tests/cookies.py
+++ b/tests/cookies.py
@@ -3,69 +3,62 @@
 # Copyright 2012 splinter authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
+import time
 
 
 class CookiesTest(object):
     def test_create_and_access_a_cookie(self):
-        "should be able to create and access a cookie"
-        self.browser.cookies.add({"sha": "zam"})
-        self.assertEqual(self.browser.cookies["sha"], "zam")
-
-    def test_create_many_cookies_at_once_as_dict(self):
-        "should be able to create many cookies at once as dict"
-        cookies = {"sha": "zam", "foo": "bar"}
-        self.browser.cookies.add(cookies)
-        self.assertEqual(self.browser.cookies["sha"], "zam")
-        self.assertEqual(self.browser.cookies["foo"], "bar")
-
-    def test_create_many_cookies_at_once_as_list(self):
-        "should be able to create many cookies at once as list"
-        cookies = [{"sha": "zam"}, {"foo": "bar"}]
-        self.browser.cookies.add(cookies)
-        self.assertEqual(self.browser.cookies["sha"], "zam")
-        self.assertEqual(self.browser.cookies["foo"], "bar")
+        """should be able to create and access a cookie"""
+        self.browser.cookies.add("sha", "zam")
+        assert 'zam' == self.browser.cookies["sha"]["value"]
 
     def test_create_some_cookies_and_delete_them_all(self):
-        "should be able to delete all cookies"
-        self.browser.cookies.add({"whatever": "and ever"})
-        self.browser.cookies.add({"anothercookie": "im bored"})
+        """should be able to delete all cookies"""
+        self.browser.cookies.add("whatever", "and ever")
+        self.browser.cookies.add("anothercookie", "im bored")
         self.browser.cookies.delete()
         self.assertEqual(self.browser.cookies, {})
 
     def test_create_and_delete_a_cookie(self):
-        "should be able to create and destroy a cookie"
+        """should be able to create and destroy a cookie"""
         self.browser.cookies.delete()
-        self.browser.cookies.add({"cookie": "with milk"})
+        self.browser.cookies.add("cookie", "with milk")
         self.browser.cookies.delete("cookie")
         self.assertEqual(self.browser.cookies, {})
 
     def test_create_and_delete_many_cookies(self):
-        "should be able to create and destroy many cookies"
+        """should be able to create and destroy many cookies"""
         self.browser.cookies.delete()
-        self.browser.cookies.add({"acookie": "cooked"})
-        self.browser.cookies.add({"anothercookie": "uncooked"})
-        self.browser.cookies.add({"notacookie": "halfcooked"})
+        self.browser.cookies.add("acookie", "cooked")
+        self.browser.cookies.add("anothercookie", "uncooked")
+        self.browser.cookies.add("notacookie", "halfcooked")
         self.browser.cookies.delete("acookie", "notacookie")
-        self.assertEqual("uncooked", self.browser.cookies["anothercookie"])
+        assert 'uncooked' == self.browser.cookies["anothercookie"]["value"]
 
     def test_try_to_destroy_an_absent_cookie_and_nothing_happens(self):
         self.browser.cookies.delete()
-        self.browser.cookies.add({"foo": "bar"})
+        self.browser.cookies.add("foo", "bar")
         self.browser.cookies.delete("mwahahahaha")
         self.assertEqual(self.browser.cookies, {"foo": "bar"})
 
     def test_create_and_get_all_cookies(self):
-        "should be able to create some cookies and retrieve them all"
+        """should be able to create some cookies and retrieve them all"""
         self.browser.cookies.delete()
-        self.browser.cookies.add({"taco": "shrimp"})
-        self.browser.cookies.add({"lavar": "burton"})
+        self.browser.cookies.add("taco", "shrimp")
+        self.browser.cookies.add("lavar", "burton")
         self.assertEqual(len(self.browser.cookies.all()), 2)
         self.browser.cookies.delete()
         self.assertEqual(self.browser.cookies.all(), {})
 
     def test_create_and_use_contains(self):
-        "should be able to create many cookies at once as dict"
-        cookies = {"sha": "zam"}
-        self.browser.cookies.add(cookies)
+        """should be able to create many cookies at once as dict"""
+        self.browser.cookies.add('sha', 'zam')
         self.assertIn("sha", self.browser.cookies)
         self.assertNotIn("foo", self.browser.cookies)
+
+    def test_cookies_extra_parameters(self):
+        """Cookie can be created with extra parameters."""
+        timestamp = int(time.time() + 120)
+        self.browser.cookies.add('sha', 'zam', expiry=timestamp)
+        cookie = self.browser.cookies["sha"]
+        assert timestamp == cookie["expiry"]

--- a/tests/test_djangoclient.py
+++ b/tests/test_djangoclient.py
@@ -6,6 +6,7 @@
 
 import os
 import sys
+import time
 import unittest
 from six.moves.urllib import parse
 
@@ -154,6 +155,26 @@ class DjangoClientDriverTest(
         for key, text in non_ascii_encodings.items():
             link = self.browser.find_link_by_text(text)
             self.assertEqual(key, link["id"])
+
+    def test_create_and_access_a_cookie(self):
+        """should be able to create and access a cookie"""
+        self.browser.cookies.add("sha", "zam")
+        assert 'zam' == self.browser.cookies["sha"].value
+
+    def test_create_and_delete_many_cookies(self):
+        """should be able to create and destroy many cookies"""
+        self.browser.cookies.delete()
+        self.browser.cookies.add("acookie", "cooked")
+        self.browser.cookies.add("anothercookie", "uncooked")
+        self.browser.cookies.add("notacookie", "halfcooked")
+        self.browser.cookies.delete("acookie", "notacookie")
+        assert 'uncooked' == self.browser.cookies["anothercookie"].value
+
+    def test_cookies_extra_parameters(self):
+        """Cookie can be created with extra parameters."""
+        timestamp = int(time.time() + 120)
+        self.browser.cookies.add('sha', 'zam', expires=timestamp)
+        assert timestamp == self.browser.cookies['sha']['expires']
 
 
 class DjangoClientDriverTestWithCustomHeaders(unittest.TestCase):

--- a/tests/test_flaskclient.py
+++ b/tests/test_flaskclient.py
@@ -5,6 +5,7 @@
 # license that can be found in the LICENSE file.
 
 import os
+import time
 import unittest
 
 from splinter import Browser
@@ -154,6 +155,25 @@ class FlaskClientDriverTest(
         self.assertIn("I just been redirected to this location", self.browser.html)
         self.assertIn("redirect-location?come=get&some=true", self.browser.url)
 
+    def test_create_and_access_a_cookie(self):
+        """should be able to create and access a cookie"""
+        self.browser.cookies.add("sha", "zam")
+        assert 'zam' == self.browser.cookies["sha"].value
+
+    def test_create_and_delete_many_cookies(self):
+        """should be able to create and destroy many cookies"""
+        self.browser.cookies.delete()
+        self.browser.cookies.add("acookie", "cooked")
+        self.browser.cookies.add("anothercookie", "uncooked")
+        self.browser.cookies.add("notacookie", "halfcooked")
+        self.browser.cookies.delete("acookie", "notacookie")
+        assert 'uncooked' == self.browser.cookies["anothercookie"].value
+
+    def test_cookies_extra_parameters(self):
+        """Cookie can be created with extra parameters."""
+        timestamp = int(time.time() + 120)
+        self.browser.cookies.add('sha', 'zam', expires=timestamp)
+        assert timestamp == self.browser.cookies["sha"].expires
 
 class FlaskClientDriverTestWithCustomHeaders(unittest.TestCase):
     @classmethod

--- a/tests/test_zopetestbrowser.py
+++ b/tests/test_zopetestbrowser.py
@@ -5,8 +5,8 @@
 # license that can be found in the LICENSE file.
 
 import os
-import unittest
 import sys
+import unittest
 
 from splinter import Browser
 from .base import BaseBrowserTests
@@ -143,3 +143,9 @@ class ZopeTestBrowserDriverTest(
         for key, text in non_ascii_encodings.iteritems():
             link = self.browser.find_link_by_text(text)
             self.assertEqual(key, link["id"])
+
+    def test_cookies_extra_parameters(self):
+        """Cookie can be created with extra parameters."""
+        comment = 'Ipsum lorem'
+        self.browser.cookies.add('sha', 'zam', comment=comment)
+        assert 'Ipsum%20lorem' == self.browser.cookies['sha']['comment']


### PR DESCRIPTION
- Add CookieManager.delete_all() method

- Standardize the init phase for CookieManager subclasses

- Remove ability to send a list to CookieManager.add(). This was undocumented and having an argument that takes multiple types seems like a bad idea.

- Rewrite CookieManager.add() to accept arguments for cookie parameters instead of a dict with a key/value for name and value parameters.

- The change to CookieManager.add() is incompatible with the current function signature, unfortunately.

- CookieManager.__ getitem __ returns the whole cookie instead of the value

The input for cookies is now standardized, with the specific arguments depending on the driver. The output from getitem depends on the driver. A future improvement could create a standard Cookie object so that every driver behaves identically.

Fixes #307, #388, and probably #743, but it needs to be tested.

@andrewsmedina Since this changes how CookieManager.add() behaves, I'd like another set of eyes on it before I merge.