### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=["selenium>=3.141.0", "six"],
     extras_require={
         "zope.testbrowser": ["zope.testbrowser>=5.2.4", "lxml>=4.2.4", "cssselect"],
-        "django": ["Django>=1.7.11;python_version<'3.0'", "Django>=2.0.6;python_version>'3.3'", "lxml>=2.3.6", "cssselect", "six"],
+        "django": ["Django>=1.7.11", "lxml>=2.3.6", "cssselect", "six"],
         "flask": ["Flask>=1.0.2", "lxml>=2.3.6", "cssselect"],
     },
     tests_require=["coverage", "flask"],


### PR DESCRIPTION
Removes pinning Django to 2.0.6+ if installing on Python 3.3 or above.  Django 1.11 supports those versions.

Closes #667 