### PR TITLE
Unit tests no longer fail on latest firefox version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 language: python
 addons:
   chrome: stable
-  firefox: "68.0"
+  firefox: latest
 python:
   - "2.7"
   - "3.6"

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,6 +3,7 @@
 # Copyright 2012 splinter authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
+import time
 
 import pytest
 from selenium import webdriver
@@ -189,6 +190,9 @@ class WebDriverTests(
         alert.fill_with("Splinter")
         alert.accept()
 
+        # Wait for alert
+        time.sleep(2.5)
+
         response = self.browser.get_alert()
         self.assertEqual("Splinter", response.text)
         response.accept()
@@ -202,6 +206,9 @@ class WebDriverTests(
         self.assertEqual("Should I continue?", alert.text)
         alert.accept()
 
+        # Wait for alert
+        time.sleep(2.5)
+
         alert = self.browser.get_alert()
         self.assertEqual("You say I should", alert.text)
         alert.accept()
@@ -210,6 +217,10 @@ class WebDriverTests(
         alert = self.browser.get_alert()
         self.assertEqual("Should I continue?", alert.text)
         alert.dismiss()
+
+        # Wait for alert
+        time.sleep(2.5)
+
         alert = self.browser.get_alert()
         self.assertEqual("You say I should not", alert.text)
         alert.accept()
@@ -222,6 +233,9 @@ class WebDriverTests(
             self.assertEqual("Should I continue?", alert.text)
             alert.accept()
 
+        # Wait for alert
+        time.sleep(2.5)
+
         with self.browser.get_alert() as alert:
             self.assertEqual("You say I should", alert.text)
             alert.accept()
@@ -230,6 +244,10 @@ class WebDriverTests(
         with self.browser.get_alert() as alert:
             self.assertEqual("Should I continue?", alert.text)
             alert.dismiss()
+
+        # Wait for alert
+        time.sleep(2.5)
+
         with self.browser.get_alert() as alert:
             self.assertEqual("You say I should not", alert.text)
             alert.accept()

--- a/tests/static/alert.html
+++ b/tests/static/alert.html
@@ -8,14 +8,23 @@
       $(document).ready(function(){
         $('.alerta').click(function() { alert('This is an alert example.'); });
 
-        $('.pergunta').click(function() { nome = prompt('What is your name?'); alert(nome); });
+        $('.pergunta').click(function() {
+            nome = prompt('What is your name?');
+            setTimeout(function(){ alert(nome); }, 2000);
+        });
 
         $('.confirmacao').click(function() {
+            var message;
             answer = confirm('Should I continue?');
-            if (answer)
-                alert("You say I should");
-            else
-                alert("You say I should not");
+
+            if (answer) {
+                message = "You say I should";
+            } else {
+                message = "You say I should not";
+            }
+            // Add sleep before 2nd alert appears, to prevent browser's
+            // popup spam warning messages.
+            setTimeout(function(){ alert(message); }, 2000);
         });
       })
     </script>


### PR DESCRIPTION
Newer versions of firefox and selenium don't play nicely when alerts are spammed.