### PR TITLE
Fix cookies test to be able to run in parallel. Fix bug with adding multiple cookies from list.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ env:
   - DRIVER='tests/test_flaskclient.py tests/test_browser.py tests/test_element_list.py tests/test_request_handler.py'
   - DRIVER=tests/test_webdriver.py
   - DRIVER=tests/test_webdriver_remote.py
-  - DRIVER=tests/test_webdriver_firefox.py
-  - DRIVER=tests/test_webdriver_chrome.py
+  - DRIVER='-n 4 tests/test_webdriver_firefox.py'
+  - DRIVER='-n 4 tests/test_webdriver_chrome.py'
 matrix:
   include:
     - python: 2.7

--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -23,7 +23,7 @@ class CookieManager(CookieManagerAPI):
             for cookie in cookies:
                 for key, value in cookie.items():
                     self._cookies[key] = value
-                return
+            return
         for key, value in cookies.items():
             self._cookies[key] = value
 

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -27,7 +27,7 @@ class CookieManager(CookieManagerAPI):
             for cookie in cookies:
                 for key, value in cookie.items():
                     self._cookies.set_cookie("localhost", key, value)
-                return
+            return
         for key, value in cookies.items():
             self._cookies.set_cookie("localhost", key, value)
 

--- a/splinter/driver/webdriver/cookie_manager.py
+++ b/splinter/driver/webdriver/cookie_manager.py
@@ -22,7 +22,7 @@ class CookieManager(CookieManagerAPI):
             for cookie in cookies:
                 for key, value in cookie.items():
                     self.driver.add_cookie({"name": key, "value": value})
-                return
+            return
         for key, value in cookies.items():
             self.driver.add_cookie({"name": key, "value": value})
 

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -31,7 +31,7 @@ class CookieManager(CookieManagerAPI):
             for cookie in cookies:
                 for key, value in cookie.items():
                     self.driver.cookies[key] = value
-                return
+            return
         for key, value in cookies.items():
             self.driver.cookies[key] = value
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,3 +12,4 @@ six==1.11.0
 twine==1.11.0
 pytest==4.6.4
 Pillow==6.2.2
+pytest-xdist==1.34.0

--- a/tests/base.py
+++ b/tests/base.py
@@ -15,7 +15,7 @@ from .async_finder import AsyncFinderTests
 from .click_elements import ClickElementsTest
 from .cookies import CookiesTest
 from .element_does_not_exist import ElementDoestNotExistTest
-from .fake_webapp import EXAMPLE_APP
+from .fake_webapp import app, EXAMPLE_APP
 from .find_elements import FindElementsTest
 from .form_elements import FormElementsTest
 from .iframes import IFrameElementsTest
@@ -40,12 +40,33 @@ def get_browser(browser_name, **kwargs):
             options=options,
             **kwargs
         )
-    else:
+    elif browser_name == 'firefox':
         return Browser(
             "firefox",
             headless=True,
             **kwargs
         )
+
+    elif browser_name == 'remote':
+        return Browser("remote")
+
+    elif browser_name == 'django':
+        components = parse.urlparse(EXAMPLE_APP)
+        return Browser(
+            "django",
+            wait_time=0.1,
+            client_SERVER_NAME=components.hostname,
+            client_SERVER_PORT=components.port,
+        )
+
+    elif browser_name == 'flask':
+        return Browser("flask", app=app, wait_time=0.1)
+
+    elif browser_name == 'zope.testbrowser':
+        return Browser("zope.testbrowser", wait_time=0.1)
+
+
+    raise ValueError('Unknown browser name')
 
 
 class BaseBrowserTests(
@@ -57,6 +78,11 @@ class BaseBrowserTests(
     SlowlyTypeTest,
     IsTextPresentTest,
 ):
+    EXAMPLE_APP = EXAMPLE_APP
+
+    def get_browser(self, browser_name, **kwargs):
+        return get_browser(browser_name, **kwargs)
+
     def test_can_open_page(self):
         """should be able to visit, get title and quit"""
         self.browser.visit(EXAMPLE_APP)

--- a/tests/cookies.py
+++ b/tests/cookies.py
@@ -6,66 +6,127 @@
 
 
 class CookiesTest(object):
+    def get_new_browser(self):
+        """Get a new browser instance."""
+        driver_name = self.browser.driver_name.lower()
+        return self.get_browser(driver_name)
+
     def test_create_and_access_a_cookie(self):
-        "should be able to create and access a cookie"
-        self.browser.cookies.add({"sha": "zam"})
-        self.assertEqual(self.browser.cookies["sha"], "zam")
+        """Should be able to create and access a cookie"""
+        browser = self.get_new_browser()
+        browser.visit(self.EXAMPLE_APP)
+
+        browser.cookies.add({"sha": "zam"})
+
+        assert "zam" == browser.cookies["sha"]
+
+        browser.quit()
 
     def test_create_many_cookies_at_once_as_dict(self):
-        "should be able to create many cookies at once as dict"
+        """Should be able to create many cookies at once as dict"""
+        browser = self.get_new_browser()
+        browser.visit(self.EXAMPLE_APP)
+
         cookies = {"sha": "zam", "foo": "bar"}
-        self.browser.cookies.add(cookies)
-        self.assertEqual(self.browser.cookies["sha"], "zam")
-        self.assertEqual(self.browser.cookies["foo"], "bar")
+        browser.cookies.add(cookies)
+
+        assert "zam" == browser.cookies["sha"]
+        assert "bar" == browser.cookies["foo"]
+
+        browser.quit()
 
     def test_create_many_cookies_at_once_as_list(self):
-        "should be able to create many cookies at once as list"
+        """Should be able to create many cookies at once as list"""
+        browser = self.get_new_browser()
+        browser.visit(self.EXAMPLE_APP)
+
         cookies = [{"sha": "zam"}, {"foo": "bar"}]
-        self.browser.cookies.add(cookies)
-        self.assertEqual(self.browser.cookies["sha"], "zam")
-        self.assertEqual(self.browser.cookies["foo"], "bar")
+        browser.cookies.add(cookies)
+
+        assert "zam" == browser.cookies["sha"]
+        assert "bar" == browser.cookies["foo"]
+
+        browser.quit()
 
     def test_create_some_cookies_and_delete_them_all(self):
-        "should be able to delete all cookies"
-        self.browser.cookies.add({"whatever": "and ever"})
-        self.browser.cookies.add({"anothercookie": "im bored"})
-        self.browser.cookies.delete()
-        self.assertEqual(self.browser.cookies, {})
+        """Should be able to delete all cookies"""
+        browser = self.get_new_browser()
+        browser.visit(self.EXAMPLE_APP)
+
+        browser.cookies.add({"whatever": "and ever"})
+        browser.cookies.add({"anothercookie": "im bored"})
+        browser.cookies.delete()
+
+        assert {} == browser.cookies
+
+        browser.quit()
 
     def test_create_and_delete_a_cookie(self):
-        "should be able to create and destroy a cookie"
-        self.browser.cookies.delete()
-        self.browser.cookies.add({"cookie": "with milk"})
-        self.browser.cookies.delete("cookie")
-        self.assertEqual(self.browser.cookies, {})
+        """Should be able to create and destroy a cookie"""
+        browser = self.get_new_browser()
+        browser.visit(self.EXAMPLE_APP)
+
+        browser.cookies.delete()
+        browser.cookies.add({"cookie": "with milk"})
+        browser.cookies.delete("cookie")
+
+        assert {} == browser.cookies
+
+        browser.quit()
 
     def test_create_and_delete_many_cookies(self):
-        "should be able to create and destroy many cookies"
-        self.browser.cookies.delete()
-        self.browser.cookies.add({"acookie": "cooked"})
-        self.browser.cookies.add({"anothercookie": "uncooked"})
-        self.browser.cookies.add({"notacookie": "halfcooked"})
-        self.browser.cookies.delete("acookie", "notacookie")
-        self.assertEqual("uncooked", self.browser.cookies["anothercookie"])
+        """Should be able to create and destroy many cookies"""
+        browser = self.get_new_browser()
+        browser.visit(self.EXAMPLE_APP)
+
+        browser.cookies.delete()
+        browser.cookies.add({"acookie": "cooked"})
+        browser.cookies.add({"anothercookie": "uncooked"})
+        browser.cookies.add({"notacookie": "halfcooked"})
+        browser.cookies.delete("acookie", "notacookie")
+
+        assert "uncooked" == browser.cookies["anothercookie"]
+
+        browser.quit()
 
     def test_try_to_destroy_an_absent_cookie_and_nothing_happens(self):
-        self.browser.cookies.delete()
-        self.browser.cookies.add({"foo": "bar"})
-        self.browser.cookies.delete("mwahahahaha")
-        self.assertEqual(self.browser.cookies, {"foo": "bar"})
+        browser = self.get_new_browser()
+        browser.visit(self.EXAMPLE_APP)
+
+        browser.cookies.delete()
+        browser.cookies.add({"foo": "bar"})
+        browser.cookies.delete("mwahahahaha")
+
+        {"foo": "bar"} == browser.cookies
+
+        browser.quit()
 
     def test_create_and_get_all_cookies(self):
-        "should be able to create some cookies and retrieve them all"
-        self.browser.cookies.delete()
-        self.browser.cookies.add({"taco": "shrimp"})
-        self.browser.cookies.add({"lavar": "burton"})
-        self.assertEqual(len(self.browser.cookies.all()), 2)
-        self.browser.cookies.delete()
-        self.assertEqual(self.browser.cookies.all(), {})
+        """Should be able to create some cookies and retrieve them all"""
+        browser = self.get_new_browser()
+        browser.visit(self.EXAMPLE_APP)
+
+        browser.cookies.delete()
+        browser.cookies.add({"taco": "shrimp"})
+        browser.cookies.add({"lavar": "burton"})
+
+        assert 2 == len(browser.cookies.all())
+
+        browser.cookies.delete()
+
+        assert {} == browser.cookies.all()
+
+        browser.quit()
 
     def test_create_and_use_contains(self):
-        "should be able to create many cookies at once as dict"
+        """Should be able to create many cookies at once as dict"""
+        browser = self.get_new_browser()
+        browser.visit(self.EXAMPLE_APP)
+
         cookies = {"sha": "zam"}
-        self.browser.cookies.add(cookies)
-        self.assertIn("sha", self.browser.cookies)
-        self.assertNotIn("foo", self.browser.cookies)
+        browser.cookies.add(cookies)
+
+        assert "sha" in browser.cookies
+        assert "foo" not in browser.cookies
+
+        browser.quit()

--- a/tests/popups.py
+++ b/tests/popups.py
@@ -20,6 +20,8 @@ class PopupWindowsTest(object):
         )
 
     def test_set_current_to_window_instance_sets_current_window(self):
+        self.browser.find_by_id("open-popup").click()
+
         last_current_window = self.browser.windows.current
         self.browser.windows.current = self.browser.windows.current.next
         self.assertNotEqual(self.browser.windows.current, last_current_window)

--- a/travis-install.bash
+++ b/travis-install.bash
@@ -18,7 +18,7 @@ if [ "${DRIVER}" = "tests/test_webdriver_remote.py" ]; then
 	sleep 1
 fi
 
-if [ "${DRIVER}" = "tests/test_webdriver_chrome.py" ] || [ "${DRIVER}" = "tests/test_webdriver.py" ]; then
+if [ "${DRIVER}" = "-n 4 tests/test_webdriver_chrome.py" ] || [ "${DRIVER}" = "tests/test_webdriver.py" ]; then
     sleep 1
 
     FILE=`mktemp`; wget "https://chromedriver.storage.googleapis.com/2.42/chromedriver_linux64.zip" -qO $FILE && unzip $FILE chromedriver -d ~; rm $FILE; chmod 777 ~/chromedriver;


### PR DESCRIPTION
- Run chrome and firefox tests in parallel. Shaves a couple of minutes off running everything.
- Rewrite cookie tests to use unique browser instances and use pytest asserts.
- Tweak popup test to not rely on state from previous test.
- Found a bug in CookieManager while trying to get the tests to run in parallel. Running everything in one browser window created false negatives.