### PR TITLE
test-requirements.txt: Upgrade lxml for Python 3.9

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 zope.testbrowser==5.5.1
-lxml==4.2.4
+lxml==4.5.2
 Flask==1.0.2
 selenium==3.141.0
 coverage==4.5.1


### PR DESCRIPTION
From the [Travis CI test output](https://travis-ci.org/github/cobrateam/splinter/jobs/717256569#L463-L465)...
```
.tox/python/lib/python3.8/site-packages/lxml/html/_setmixin.py:1
  /home/travis/build/cobrateam/splinter/.tox/python/lib/python3.8/site-packages/lxml/html/_setmixin.py:1:
    DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is
      deprecated since Python 3.3, and in 3.9 it will stop working
        from collections import MutableSet
```