### PR TITLE
Fix the generated screenshot filename when the absolute path to a file is used

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -623,11 +623,12 @@ class BaseWebDriver(DriverAPI):
 
     def screenshot(self, name="", suffix=".png", full=False):
 
-        name = name or ""
+        filename = name or ""
 
-        (fd, filename) = tempfile.mkstemp(prefix=name, suffix=suffix)
-        # don't hold the file
-        os.close(fd)
+        if not filename:
+            (fd, filename) = tempfile.mkstemp(prefix=name, suffix=suffix)
+            # don't hold the file
+            os.close(fd)
 
         if full:
             ori_window_size = self.driver.get_window_size()

--- a/tests/screenshot.py
+++ b/tests/screenshot.py
@@ -5,6 +5,7 @@
 # license that can be found in the LICENSE file.
 
 import tempfile
+import re
 
 
 class ScreenshotTest(object):
@@ -17,6 +18,10 @@ class ScreenshotTest(object):
         """Should add the prefix to the screenshot file name"""
         filename = self.browser.screenshot(name="foobar")
         assert "foobar" in filename
+
+    def test_take_screenshot_with_absolute_path_file(self):
+        filename = self.browser.screenshot(name='/tmp/foobar.png')
+        assert re.match(r"^/tmp/foobar\.png$", filename)
 
     def test_take_screenshot_with_suffix(self):
         """Should add the suffix to the screenshot file name"""


### PR DESCRIPTION
Problem: If a an absolute path to the screenshot file is defined, Splinter doesn't respect it and append a random file name to the final filename.

This problem seems to have gone unnoticed for the past 7 years.
This is the line where the error occurs:
https://github.com/cobrateam/splinter/blob/d28efabdf64c45a55fb349980f134f5a5edbd1c9/splinter/driver/webdriver/__init__.py#L628

This is the demonstration of the bug

```python
Python 3.8.4 (default, Jul 21 2020, 11:47:41) 
[GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import tempfile
>>> name = "/tmp/test.png"
>>> suffix = ".png"
>>> (fd, filename) = tempfile.mkstemp(prefix=name, suffix=suffix)
>>> filename
'/tmp/test.png7hfkpela.png'
```

The expected filename is `/tmp/test.png` but was returned `/tmp/test.png7hfkpela.png`

This pull-request fix that problem.