### PR TITLE
Fix flaky unit tests by using unique browser instances

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -81,8 +81,10 @@ class BaseBrowserTests(
 ):
     EXAMPLE_APP = EXAMPLE_APP
 
-    def get_browser(self, browser_name, **kwargs):
-        return get_browser(browser_name, **kwargs)
+    def get_new_browser(self):
+        """Get a new browser instance."""
+        driver_name = self.browser.driver_name.lower()
+        return get_browser(driver_name)
 
     def test_can_open_page(self):
         """should be able to visit, get title and quit"""

--- a/tests/cookies.py
+++ b/tests/cookies.py
@@ -6,11 +6,6 @@
 
 
 class CookiesTest(object):
-    def get_new_browser(self):
-        """Get a new browser instance."""
-        driver_name = self.browser.driver_name.lower()
-        return self.get_browser(driver_name)
-
     def test_create_and_access_a_cookie(self):
         """Should be able to create and access a cookie"""
         browser = self.get_new_browser()

--- a/tests/popups.py
+++ b/tests/popups.py
@@ -7,38 +7,44 @@
 
 class PopupWindowsTest(object):
     def test_lists_all_windows_as_window_instances(self):
-        self.browser.find_by_id("open-popup").click()
-        self.assertEqual(len(self.browser.windows), 2)
+        browser = self.get_new_browser()
+        browser.visit(self.EXAMPLE_APP)
+        browser.find_by_id("open-popup").click()
+
+        assert 2 == len(browser.windows)
+
         for window, handle in zip(
-            self.browser.windows, self.browser.driver.window_handles
+            browser.windows, browser.driver.window_handles
         ):
-            self.assertEqual(window.name, handle)
+            assert window.name == handle
+
+        browser.quit()
 
     def test_current_is_a_window_instance_pointing_to_current_window(self):
-        self.assertEqual(
-            self.browser.windows.current.name, self.browser.driver.current_window_handle
-        )
+        assert self.browser.windows.current.name == self.browser.driver.current_window_handle
 
     def test_set_current_to_window_instance_sets_current_window(self):
         self.browser.find_by_id("open-popup").click()
 
         last_current_window = self.browser.windows.current
         self.browser.windows.current = self.browser.windows.current.next
-        self.assertNotEqual(self.browser.windows.current, last_current_window)
+        assert self.browser.windows.current != last_current_window
 
     def test_next_prev_return_next_prev_windows(self):
-        self.browser.find_by_id("open-popup").click()
-        self.assertEqual(
-            self.browser.windows.current.next, self.browser.windows.current.prev
-        )
-        self.assertNotEqual(
-            self.browser.windows.current, self.browser.windows.current.next
-        )
+        browser = self.get_new_browser()
+        browser.visit(self.EXAMPLE_APP)
+        browser.find_by_id("open-popup").click()
+
+        assert browser.windows.current.next == browser.windows.current.prev
+        assert browser.windows.current != browser.windows.current.next
+
+        browser.quit()
 
     def test_is_current_returns_true_if_current_window_else_false(self):
         self.browser.find_by_id("open-popup").click()
-        self.assertTrue(self.browser.windows.current.is_current)
-        self.assertFalse(self.browser.windows.current.next.is_current)
+
+        assert self.browser.windows.current.is_current
+        assert not self.browser.windows.current.next.is_current
 
         # Close popup window
         self.browser.windows.current.close_others()
@@ -46,28 +52,26 @@ class PopupWindowsTest(object):
     def test_set_is_current_to_True_sets_window_to_current(self):
         self.browser.find_by_id("open-popup").click()
         next_window = self.browser.windows.current.next
-        self.assertFalse(next_window.is_current)
+        assert not next_window.is_current
         next_window.is_current = True
-        self.assertEqual(self.browser.windows.current, next_window)
-        self.assertTrue(next_window.is_current)
+        assert self.browser.windows.current == next_window
+        assert next_window.is_current
 
     def test_get_window_by_index(self):
         self.browser.find_by_id("open-popup").click()
-        self.assertEqual(
-            self.browser.windows[0].name, self.browser.driver.window_handles[0]
-        )
+        assert self.browser.windows[0].name == self.browser.driver.window_handles[0]
 
     def test_get_window_by_name(self):
         self.browser.find_by_id("open-popup").click()
         window_handle = self.browser.driver.window_handles[0]
-        self.assertEqual(self.browser.windows[window_handle].name, window_handle)
+        assert self.browser.windows[window_handle].name == window_handle
 
     def test_close_closes_window(self):
         self.browser.find_by_id("open-popup").click()
         current = self.browser.windows.current
         current.next.close()
-        self.assertEqual(len(self.browser.windows), 1)
-        self.assertEqual(self.browser.windows.current, current)
+        assert 1 == len(self.browser.windows)
+        assert self.browser.windows.current == current
 
     def test_close_current_window_expect_previous_window_becomes_current(self):
         self.browser.find_by_id("open-popup").click()
@@ -75,12 +79,12 @@ class PopupWindowsTest(object):
         current = prev.next
         prev.next.is_current = True
         current.close()
-        self.assertEqual(len(self.browser.windows), 1)
-        self.assertEqual(self.browser.windows.current, prev)
+        assert 1 == len(self.browser.windows)
+        assert self.browser.windows.current == prev
 
     def test_close_others_expect_close_all_other_open_windows(self):
         current = self.browser.windows.current
         self.browser.find_by_id("open-popup").click()
         current.close_others()
-        self.assertEqual(self.browser.windows[0], current)
-        self.assertEqual(len(self.browser.windows), 1)
+        assert self.browser.windows[0] == current
+        assert 1 == len(self.browser.windows)


### PR DESCRIPTION
Fixes #792

Rewrites the popups tests to use pytest asserts instead of unittest functions