### PR TITLE
Standardize init of CookieManager

### DIFF
--- a/splinter/cookie_manager.py
+++ b/splinter/cookie_manager.py
@@ -22,6 +22,9 @@ class CookieManagerAPI(InheritedDocs("_CookieManagerAPI", (object,), {})):
         >>> assert cookie_manager['name'] == 'Tony'
     """
 
+    def __init__(self, driver):
+        self.driver = driver
+
     def add(self, cookies):
         """
         Adds a cookie.

--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -15,44 +15,41 @@ from .lxmldriver import LxmlDriver
 
 
 class CookieManager(CookieManagerAPI):
-    def __init__(self, browser_cookies):
-        self._cookies = browser_cookies
-
     def add(self, cookies):
         if isinstance(cookies, list):
             for cookie in cookies:
                 for key, value in cookie.items():
-                    self._cookies[key] = value
+                    self.driver.cookies[key] = value
             return
         for key, value in cookies.items():
-            self._cookies[key] = value
+            self.driver.cookies[key] = value
 
     def delete(self, *cookies):
         if cookies:
             for cookie in cookies:
                 try:
-                    del self._cookies[cookie]
+                    del self.driver.cookies[cookie]
                 except KeyError:
                     pass
         else:
-            self._cookies.clear()
+            self.driver.cookies.clear()
 
     def all(self, verbose=False):
         cookies = {}
-        for key, value in self._cookies.items():
+        for key, value in self.driver.cookies.items():
             cookies[key] = value
         return cookies
 
     def __getitem__(self, item):
-        return self._cookies[item].value
+        return self.driver.cookies[item].value
 
     def __contains__(self, key):
-        return key in self._cookies
+        return key in self.driver.cookies
 
     def __eq__(self, other_object):
         if isinstance(other_object, dict):
             cookies_dict = dict(
-                [(key, morsel.value) for key, morsel in self._cookies.items()]
+                [(key, morsel.value) for key, morsel in self.driver.cookies.items()]
             )
             return cookies_dict == other_object
         return False
@@ -74,7 +71,7 @@ class DjangoClient(LxmlDriver):
 
         self._browser = Client(**client_kwargs)
         self._user_agent = user_agent
-        self._cookie_manager = CookieManager(self._browser.cookies)
+        self._cookie_manager = CookieManager(self._browser)
         super(DjangoClient, self).__init__(wait_time=wait_time)
 
     def __enter__(self):

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -19,47 +19,44 @@ from .lxmldriver import LxmlDriver
 
 
 class CookieManager(CookieManagerAPI):
-    def __init__(self, browser_cookies):
-        self._cookies = browser_cookies
-
     def add(self, cookies):
         if isinstance(cookies, list):
             for cookie in cookies:
                 for key, value in cookie.items():
-                    self._cookies.set_cookie("localhost", key, value)
+                    self.driver.set_cookie("localhost", key, value)
             return
         for key, value in cookies.items():
-            self._cookies.set_cookie("localhost", key, value)
+            self.driver.set_cookie("localhost", key, value)
 
     def delete(self, *cookies):
         if cookies:
             for cookie in cookies:
                 try:
-                    self._cookies.delete_cookie("localhost", cookie)
+                    self.driver.delete_cookie("localhost", cookie)
                 except KeyError:
                     pass
         else:
-            self._cookies.cookie_jar.clear()
+            self.driver.cookie_jar.clear()
 
     def all(self, verbose=False):
         cookies = {}
-        for cookie in self._cookies.cookie_jar:
+        for cookie in self.driver.cookie_jar:
             cookies[cookie.name] = cookie.value
         return cookies
 
     def __getitem__(self, item):
-        cookies = dict([(c.name, c) for c in self._cookies.cookie_jar])
+        cookies = dict([(c.name, c) for c in self.driver.cookie_jar])
         return cookies[item].value
 
     def __contains__(self, key):
-        for cookie in self._cookies.cookie_jar:
+        for cookie in self.driver.cookie_jar:
             if cookie.name == key:
                 return True
         return False
 
     def __eq__(self, other_object):
         if isinstance(other_object, dict):
-            cookies_dict = dict([(c.name, c.value) for c in self._cookies.cookie_jar])
+            cookies_dict = dict([(c.name, c.value) for c in self.driver.cookie_jar])
             return cookies_dict == other_object
         return False
 

--- a/splinter/driver/webdriver/cookie_manager.py
+++ b/splinter/driver/webdriver/cookie_manager.py
@@ -14,9 +14,6 @@ else:
 
 
 class CookieManager(CookieManagerAPI):
-    def __init__(self, driver):
-        self.driver = driver
-
     def add(self, cookies):
         if isinstance(cookies, list):
             for cookie in cookies:

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -23,9 +23,6 @@ from splinter.cookie_manager import CookieManagerAPI
 
 
 class CookieManager(CookieManagerAPI):
-    def __init__(self, driver):
-        self.driver = driver
-
     def add(self, cookies):
         if isinstance(cookies, list):
             for cookie in cookies:


### PR DESCRIPTION
The init method in all the CookieManager implementations can be identical.