### PR TITLE
Add delete_all method to CookieManager

### DIFF
--- a/splinter/cookie_manager.py
+++ b/splinter/cookie_manager.py
@@ -54,6 +54,12 @@ class CookieManagerAPI(InheritedDocs("_CookieManagerAPI", (object,), {})):
         """
         raise NotImplementedError
 
+    def delete_all(self):
+        """
+        Delete all cookies.
+        """
+        raise NotImplementedError
+
     def all(self, verbose=False):
         """
         Returns all of the cookies.

--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -31,7 +31,10 @@ class CookieManager(CookieManagerAPI):
                 except KeyError:
                     pass
         else:
-            self.driver.cookies.clear()
+            self.delete_all()
+
+    def delete_all(self):
+        self.driver.cookies.clear()
 
     def all(self, verbose=False):
         cookies = {}

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -34,7 +34,10 @@ class CookieManager(CookieManagerAPI):
                 except KeyError:
                     pass
         else:
-            self.driver.cookie_jar.clear()
+            self.delete_all()
+
+    def delete_all(self):
+        self.driver.cookie_jar.clear()
 
     def all(self, verbose=False):
         cookies = {}

--- a/splinter/driver/webdriver/cookie_manager.py
+++ b/splinter/driver/webdriver/cookie_manager.py
@@ -28,7 +28,10 @@ class CookieManager(CookieManagerAPI):
             for cookie in cookies:
                 self.driver.delete_cookie(cookie)
         else:
-            self.driver.delete_all_cookies()
+            self.delete_all()
+
+    def delete_all(self):
+        self.driver.delete_all_cookies()
 
     def all(self, verbose=False):
         if not verbose:

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -40,7 +40,10 @@ class CookieManager(CookieManagerAPI):
                 except KeyError:
                     pass
         else:
-            self.driver.cookies.clearAll()
+            self.delete_all()
+
+    def delete_all(self):
+        self.driver.cookies.clearAll()
 
     def all(self, verbose=False):
         cookies = {}


### PR DESCRIPTION
Creates a standard call for deleting all cookies.