### PR TITLE
Remove sending a list of cookie dicts to CookieManager.add()

### DIFF
--- a/splinter/cookie_manager.py
+++ b/splinter/cookie_manager.py
@@ -25,9 +25,9 @@ class CookieManagerAPI(InheritedDocs("_CookieManagerAPI", (object,), {})):
     def __init__(self, driver):
         self.driver = driver
 
-    def add(self, cookies):
+    def add(self, cookie):
         """
-        Adds a cookie.
+        Add a cookie.
 
         The ``cookie`` parameter is a ``dict`` where each key is an identifier
         for the cookie value (like any ``dict``).

--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -12,8 +12,6 @@ from splinter.request_handler.status_code import StatusCode
 
 from .lxmldriver import LxmlDriver
 
-import warnings
-
 
 class CookieManager(CookieManagerAPI):
     def add(self, cookie):

--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -16,18 +16,8 @@ import warnings
 
 
 class CookieManager(CookieManagerAPI):
-    def add(self, cookies):
-        if isinstance(cookies, list):
-            warnings.warn(
-                'Using a list of cookies is deprecated.'
-                ' Version 0.16.0 will only accept one cookie at a time.',
-                FutureWarning,
-            )
-            for cookie in cookies:
-                for key, value in cookie.items():
-                    self.driver.cookies[key] = value
-            return
-        for key, value in cookies.items():
+    def add(self, cookie):
+        for key, value in cookie.items():
             self.driver.cookies[key] = value
 
     def delete(self, *cookies):

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -15,8 +15,6 @@ from splinter.request_handler.status_code import StatusCode
 
 from .lxmldriver import LxmlDriver
 
-import warnings
-
 
 class CookieManager(CookieManagerAPI):
     def add(self, cookie):

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -19,18 +19,8 @@ import warnings
 
 
 class CookieManager(CookieManagerAPI):
-    def add(self, cookies):
-        if isinstance(cookies, list):
-            warnings.warn(
-                'Using a list of cookies is deprecated.'
-                ' Version 0.16.0 will only accept one cookie at a time.',
-                FutureWarning,
-            )
-            for cookie in cookies:
-                for key, value in cookie.items():
-                    self.driver.set_cookie("localhost", key, value)
-            return
-        for key, value in cookies.items():
+    def add(self, cookie):
+        for key, value in cookie.items():
             self.driver.set_cookie("localhost", key, value)
 
     def delete(self, *cookies):

--- a/splinter/driver/webdriver/cookie_manager.py
+++ b/splinter/driver/webdriver/cookie_manager.py
@@ -12,8 +12,6 @@ if sys.version_info[0] > 2:
 else:
     from urlparse import urlparse  # NOQA
 
-import warnings
-
 
 class CookieManager(CookieManagerAPI):
     def add(self, cookie):

--- a/splinter/driver/webdriver/cookie_manager.py
+++ b/splinter/driver/webdriver/cookie_manager.py
@@ -16,18 +16,8 @@ import warnings
 
 
 class CookieManager(CookieManagerAPI):
-    def add(self, cookies):
-        if isinstance(cookies, list):
-            warnings.warn(
-                'Using a list of cookies is deprecated.'
-                ' Version 0.16.0 will only accept one cookie at a time.',
-                FutureWarning,
-            )
-            for cookie in cookies:
-                for key, value in cookie.items():
-                    self.driver.add_cookie({"name": key, "value": value})
-            return
-        for key, value in cookies.items():
+    def add(self, cookie):
+        for key, value in cookie.items():
             self.driver.add_cookie({"name": key, "value": value})
 
     def delete(self, *cookies):

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -9,7 +9,6 @@ from __future__ import unicode_literals
 import mimetypes
 import re
 import time
-import warnings
 
 import lxml.html
 from lxml.cssselect import CSSSelector

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -24,18 +24,8 @@ from splinter.cookie_manager import CookieManagerAPI
 
 
 class CookieManager(CookieManagerAPI):
-    def add(self, cookies):
-        if isinstance(cookies, list):
-            warnings.warn(
-                'Using a list of cookies is deprecated.'
-                ' Version 0.16.0 will only accept one cookie at a time.',
-                FutureWarning,
-            )
-            for cookie in cookies:
-                for key, value in cookie.items():
-                    self.driver.cookies[key] = value
-            return
-        for key, value in cookies.items():
+    def add(self, cookie):
+        for key, value in cookie.items():
             self.driver.cookies[key] = value
 
     def delete(self, *cookies):

--- a/tests/cookies.py
+++ b/tests/cookies.py
@@ -30,19 +30,6 @@ class CookiesTest(object):
 
         browser.quit()
 
-    def test_create_many_cookies_at_once_as_list(self):
-        """Should be able to create many cookies at once as list"""
-        browser = self.get_new_browser()
-        browser.visit(self.EXAMPLE_APP)
-
-        cookies = [{"sha": "zam"}, {"foo": "bar"}]
-        browser.cookies.add(cookies)
-
-        assert "zam" == browser.cookies["sha"]
-        assert "bar" == browser.cookies["foo"]
-
-        browser.quit()
-
     def test_create_some_cookies_and_delete_them_all(self):
         """Should be able to delete all cookies"""
         browser = self.get_new_browser()


### PR DESCRIPTION
Adding cookies with a list, eg:

```
my_list = [{...}, {...}]
CookieManager.add(my_list)
```

has always been undocumented.  Having an argument that takes multiple types seems like a bad idea. If a user really wants to add multiple cookies, it's more likely they're doing:

```
for c in cookies:
    CookieManager.add(c)
```
