### PR TITLE
Remove python 3.3, 3.4, 3.5 from setup.py, add 3.9. Add 3.9 to CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 before_install:
   - export DISPLAY=:99.0
   - travis_retry wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
     ]
-    + [("Programming Language :: Python :: %s" % x) for x in "2.7 3.3 3.4 3.5 3.6 3.7 3.8".split()],
+    + [("Programming Language :: Python :: %s" % x) for x in "2.7 3.6 3.7 3.8 3.9".split()],
     packages=find_packages(exclude=["docs", "tests", "samples"]),
     include_package_data=True,
     install_requires=["selenium>=3.141.0", "six"],


### PR DESCRIPTION
We haven't tested 3.3, 3.4 or 3.5 in years, may as well remove them officially. 3.9.0 released in October 2020, so it seems a good time to add it.