### PR TITLE
Implement plugin system

### DIFF
--- a/splinter/__init__.py
+++ b/splinter/__init__.py
@@ -4,5 +4,8 @@
 
 from splinter.browser import Browser  # NOQA
 
+from splinter.plugin_manager import hookimpl, plugins
 
 __version__ = "0.14.0"
+
+__all__ = ['hookimpl', 'plugins']

--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -32,8 +32,8 @@ from splinter.driver import DriverAPI, ElementAPI
 from splinter.driver.find_links import FindLinks
 from splinter.driver.xpath_utils import _concat_xpath_from_str
 from splinter.element_list import ElementList
-
 from splinter.exceptions import ElementDoesNotExist
+from splinter.plugin_manager import plugins
 
 
 if sys.version_info[0] > 2:
@@ -290,6 +290,8 @@ class BaseWebDriver(DriverAPI):
 
         self.links = FindLinks(self)
 
+        self.hook = plugins.hook
+
     def __enter__(self):
         return self
 
@@ -314,6 +316,7 @@ class BaseWebDriver(DriverAPI):
 
     def visit(self, url):
         self.driver.get(url)
+        self.hook.splinter_after_visit(browser=self)
 
     def back(self):
         self.driver.back()
@@ -684,6 +687,8 @@ class BaseWebDriver(DriverAPI):
         ).first._element.click()
 
     def quit(self):
+        self.hook.splinter_before_quit(browser=self)
+
         try:
             self.driver.quit()
         except WebDriverException:

--- a/splinter/hookspecs.py
+++ b/splinter/hookspecs.py
@@ -1,0 +1,35 @@
+import pluggy
+
+
+hookspec = pluggy.HookspecMarker('splinter')
+
+
+@hookspec
+def splinter_after_visit(browser):
+    """Is run after browser.visit()
+
+    Arguments:
+        browser (Browser): Current browser instance.
+    """
+    pass
+
+
+@hookspec
+def splinter_before_quit(browser):
+    """Is run before browser.quit().
+
+    Arguments:
+        browser (Browser): Current browser instance.
+    """
+    pass
+
+
+@hookspec
+def splinter_prepare_drivers(drivers):
+    # type(Dict[str, Callable]) -> Dict[str, Callable]
+    """Called before a driver is initialized.
+
+    Arguments:
+        drivers: Dict containing name: driver mappings
+    """
+    pass

--- a/splinter/plugin_manager.py
+++ b/splinter/plugin_manager.py
@@ -1,0 +1,9 @@
+import pluggy
+
+from splinter import hookspecs
+
+
+hookimpl = pluggy.HookimplMarker('splinter')
+
+plugins = pluggy.PluginManager('splinter')
+plugins.add_hookspecs(hookspecs)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,74 @@
+from .base import get_browser
+from .fake_webapp import EXAMPLE_APP
+
+import splinter
+
+
+class DummyPlugin:
+    """Bare bones dummy pluggin."""
+    @splinter.hookimpl
+    def splinter_after_visit(self, browser):
+        return 'after visit'
+
+    @splinter.hookimpl
+    def splinter_before_quit(self, browser):
+        return 'before quit'
+
+
+class DummyPlugin2:
+    """Dummy plugin with effects that can be seen."""
+    @splinter.hookimpl
+    def splinter_after_visit(self, browser):
+        browser.execute_script('document.foo = "after visit"')
+
+    @splinter.hookimpl
+    def splinter_before_quit(self, browser):
+        splinter.foo = 'bar'
+
+
+splinter.plugins.register(DummyPlugin())
+splinter.plugins.register(DummyPlugin2())
+
+
+def test_splinter_after_visit_register(request):
+    """Hook should be registered."""
+
+    browser = get_browser('chrome')
+    request.addfinalizer(browser.quit)
+
+    results = browser.hook.splinter_after_visit(browser=browser)
+
+    assert ['after visit'] == results
+
+
+def test_splinter_before_quit_register(request):
+    """Hook should be registered."""
+
+    browser = get_browser('chrome')
+    request.addfinalizer(browser.quit)
+
+    results = browser.hook.splinter_before_quit(browser=browser)
+
+    assert ['before quit'] == results
+
+
+def test_splinter_after_visit(request):
+    """Hooks should run correctly."""
+
+    browser = get_browser('chrome')
+    request.addfinalizer(browser.quit)
+
+    browser.visit(EXAMPLE_APP)
+
+    result = browser.evaluate_script("document.foo")
+
+    assert 'after visit' == result
+
+
+def test_splinter_before_quit(request):
+    """Hooks should run correctly."""
+
+    browser = get_browser('chrome')
+    browser.quit()
+
+    assert splinter.foo == 'bar'


### PR DESCRIPTION
This solution uses Pluggy https://pluggy.readthedocs.io/en/latest/ to add a plugin system into Splinter.

This PR features hooks for:
- registering external drivers. This implements #164 and provides a solution for #25. Internet Explorer is an old browser at this point, but a custom driver could be dropped in without hacking splinter's internals.
- Performing actions after a page is navigated to
- Performing actions before closing the browser.

Plugins classes or modules can be registered via a call to `splinter.plugins.register()`

This PR is missing:
- Hooks implementation for non-webdriver drivers
- Documentation

But will be added if the overall approach works.