### PR TITLE
Updated doc for Mac os

### DIFF
--- a/docs/drivers/chrome.rst
+++ b/docs/drivers/chrome.rst
@@ -47,7 +47,7 @@ The recommended way is by using `Homebrew <http://mxcl.github.com/homebrew/>`_:
 
 ::
 
-    $ brew cask install chromedriver
+    $ brew install chromedriver
 
 
 Linux


### PR DESCRIPTION
`brew cask install chromedriver` no longer works. See here https://github.com/Homebrew/discussions/discussions/902#discussioncomment-398348

Also, I just tried `brew install chromedriver` and that works too. No cask required!