### PR TITLE
allow passing options to Firefox webdriver

### DIFF
--- a/splinter/driver/webdriver/chrome.py
+++ b/splinter/driver/webdriver/chrome.py
@@ -25,7 +25,7 @@ class WebDriver(BaseWebDriver):
         **kwargs
     ):
 
-        options = Options() if options is None else options
+        options = options or Options()
 
         if user_agent is not None:
             options.add_argument("--user-agent=" + user_agent)

--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -41,7 +41,7 @@ class WebDriver(BaseWebDriver):
         firefox_capabilities = DesiredCapabilities().FIREFOX
         firefox_capabilities["marionette"] = True
 
-        options = Options() if options is None else options
+        options = options or Options()
 
         if capabilities:
             for key, value in capabilities.items():

--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -20,6 +20,7 @@ class WebDriver(BaseWebDriver):
 
     def __init__(
         self,
+        options=None,
         profile=None,
         extensions=None,
         user_agent=None,

--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -40,7 +40,7 @@ class WebDriver(BaseWebDriver):
         firefox_capabilities = DesiredCapabilities().FIREFOX
         firefox_capabilities["marionette"] = True
 
-        firefox_options = Options()
+        options = Options() if options is None else options
 
         if capabilities:
             for key, value in capabilities.items():
@@ -58,15 +58,15 @@ class WebDriver(BaseWebDriver):
                 firefox_profile.add_extension(extension)
 
         if headless:
-            firefox_options.add_argument("--headless")
+            options.add_argument("--headless")
 
         if incognito:
-            firefox_options.add_argument("-private")
+            options.add_argument("-private")
 
         self.driver = Firefox(
             firefox_profile,
             capabilities=firefox_capabilities,
-            options=firefox_options,
+            options=options,
             timeout=timeout,
             **kwargs
         )


### PR DESCRIPTION
This change matches what's in chrome.py#L28 to allow passing in options when
creating a new Browser() window. Also renamed variable from `firefox_options` to
just `options` to make it generic to match chrome.py.

```
from selenium.webdriver import Firefox, FirefoxOptions
opts = FirefoxOptions()
opts.add_argument("--some-argument")
browser = Browser('firefox', options=opts)
```