### PR TITLE
Accept extra arguments for cookies

### DIFF
--- a/splinter/cookie_manager.py
+++ b/splinter/cookie_manager.py
@@ -25,7 +25,7 @@ class CookieManagerAPI(InheritedDocs("_CookieManagerAPI", (object,), {})):
     def __init__(self, driver):
         self.driver = driver
 
-    def add(self, cookie):
+    def add(self, cookie, **kwargs):
         """
         Add a cookie.
 

--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -14,9 +14,11 @@ from .lxmldriver import LxmlDriver
 
 
 class CookieManager(CookieManagerAPI):
-    def add(self, cookie):
+    def add(self, cookie, **kwargs):
         for key, value in cookie.items():
             self.driver.cookies[key] = value
+            for k, v in kwargs.items():
+                self.driver.cookies[key][k] = v
 
     def delete(self, *cookies):
         if cookies:

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -17,9 +17,12 @@ from .lxmldriver import LxmlDriver
 
 
 class CookieManager(CookieManagerAPI):
-    def add(self, cookie):
+    def add(self, cookie, **kwargs):
         for key, value in cookie.items():
-            self.driver.set_cookie("localhost", key, value)
+            kwargs['server_name'] = "localhost"
+            kwargs['key'] = key
+            kwargs['value'] = value
+            self.driver.set_cookie(**kwargs)
 
     def delete(self, *cookies):
         if cookies:

--- a/splinter/driver/webdriver/cookie_manager.py
+++ b/splinter/driver/webdriver/cookie_manager.py
@@ -14,9 +14,11 @@ else:
 
 
 class CookieManager(CookieManagerAPI):
-    def add(self, cookie):
+    def add(self, cookie, **kwargs):
         for key, value in cookie.items():
-            self.driver.add_cookie({"name": key, "value": value})
+            kwargs['name'] = key
+            kwargs['value'] = value
+            self.driver.add_cookie(kwargs)
 
     def delete(self, *cookies):
         if cookies:

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -23,9 +23,14 @@ from splinter.cookie_manager import CookieManagerAPI
 
 
 class CookieManager(CookieManagerAPI):
-    def add(self, cookie):
+    def add(self, cookie, **kwargs):
         for key, value in cookie.items():
-            self.driver.cookies[key] = value
+            kwargs['name'] = key
+            kwargs['value'] = value
+            if key not in self.driver.cookies:
+                self.driver.cookies.create(**kwargs)
+            else:
+                self.driver.cookies.change(**kwargs)
 
     def delete(self, *cookies):
         if cookies:

--- a/tests/cookies.py
+++ b/tests/cookies.py
@@ -3,6 +3,7 @@
 # Copyright 2012 splinter authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
+import time
 
 
 class CookiesTest(object):
@@ -112,3 +113,10 @@ class CookiesTest(object):
         assert "foo" not in browser.cookies
 
         browser.quit()
+
+    def test_cookies_extra_parameters(self):
+        """Cookie can be created with extra parameters."""
+        timestamp = int(time.time() + 120)
+        self.browser.cookies.add({'sha': 'zam'}, expiry=timestamp)
+        cookie = self.browser.driver.get_cookie('sha')
+        assert timestamp == cookie["expiry"]

--- a/tests/test_djangoclient.py
+++ b/tests/test_djangoclient.py
@@ -6,6 +6,7 @@
 
 import os
 import sys
+import time
 import unittest
 from six.moves.urllib import parse
 
@@ -154,6 +155,13 @@ class DjangoClientDriverTest(
         for key, text in non_ascii_encodings.items():
             link = self.browser.find_link_by_text(text)
             self.assertEqual(key, link["id"])
+
+    def test_cookies_extra_parameters(self):
+        """Cookie can be created with extra parameters."""
+        timestamp = int(time.time() + 120)
+        self.browser.cookies.add({'sha': 'zam'}, expires=timestamp)
+        cookie = self.browser._browser.cookies['sha']
+        assert timestamp == cookie['expires']
 
 
 class DjangoClientDriverTestWithCustomHeaders(unittest.TestCase):

--- a/tests/test_flaskclient.py
+++ b/tests/test_flaskclient.py
@@ -175,7 +175,7 @@ class FlaskClientDriverTest(
         """Cookie can be created with extra parameters."""
         timestamp = int(time.time() + 120)
         self.browser.cookies.add({'sha': 'zam'}, expires=timestamp)
-        cookie = {c.name: c for c in self.driver.cookie_jar}['sha']
+        cookie = {c.name: c for c in self.browser._browser.cookie_jar}['sha']
         assert timestamp == cookie.expires
 
 

--- a/tests/test_flaskclient.py
+++ b/tests/test_flaskclient.py
@@ -5,6 +5,7 @@
 # license that can be found in the LICENSE file.
 
 import os
+import time
 import unittest
 
 from splinter import Browser
@@ -169,6 +170,13 @@ class FlaskClientDriverTest(
         self.browser.find_by_name("redirect").click()
         self.assertIn("I just been redirected to this location", self.browser.html)
         self.assertIn("redirect-location?come=get&some=true", self.browser.url)
+
+    def test_cookies_extra_parameters(self):
+        """Cookie can be created with extra parameters."""
+        timestamp = int(time.time() + 120)
+        self.browser.cookies.add({'sha': 'zam'}, expires=timestamp)
+        cookie = {c.name: c for c in self.driver.cookie_jar}['sha']
+        assert timestamp == cookie.expires
 
 
 class FlaskClientDriverTestWithCustomHeaders(unittest.TestCase):

--- a/tests/test_zopetestbrowser.py
+++ b/tests/test_zopetestbrowser.py
@@ -172,5 +172,5 @@ class ZopeTestBrowserDriverTest(
         """Cookie can be created with extra parameters."""
         comment = 'Ipsum lorem'
         self.browser.cookies.add({'sha': 'zam'}, comment=comment)
-        cookie = self.browser._browser.cookies['sha']
+        cookie = self.browser._browser.cookies.getinfo('sha')
         assert 'Ipsum%20lorem' == cookie['comment']

--- a/tests/test_zopetestbrowser.py
+++ b/tests/test_zopetestbrowser.py
@@ -167,3 +167,10 @@ class ZopeTestBrowserDriverTest(
             self.browser.fill_form(
                 {"query": "new query", "missing_form": "doesn't exist"},
             )
+
+    def test_cookies_extra_parameters(self):
+        """Cookie can be created with extra parameters."""
+        comment = 'Ipsum lorem'
+        self.browser.cookies.add({'sha': 'zam'}, comment=comment)
+        cookie = self.browser._browser.cookies['sha']
+        assert 'Ipsum%20lorem' == cookie['comment']


### PR DESCRIPTION
The goal of this PR is to allow cookies to be created with whatever arguments the driver accepts. Fixes #388