### PR TITLE
Allow BaseWebDriver to be used directly

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -30,7 +30,7 @@ from splinter.driver import DriverAPI, ElementAPI
 from splinter.driver.find_links import FindLinks
 from splinter.driver.xpath_utils import _concat_xpath_from_str
 from splinter.element_list import ElementList
-
+from splinter.driver.webdriver.cookie_manager import CookieManager
 from splinter.exceptions import ElementDoesNotExist
 
 
@@ -284,10 +284,16 @@ class BaseWebDriver(DriverAPI):
     driver = None
     find_by = find_by
 
-    def __init__(self, wait_time=2):
+    def __init__(self, driver=None, wait_time=2):
         self.wait_time = wait_time
 
         self.links = FindLinks(self)
+
+        self.driver = driver
+
+        self.element_class = WebDriverElement
+
+        self._cookie_manager = CookieManager(self.driver)
 
     def __enter__(self):
         return self

--- a/splinter/driver/webdriver/chrome.py
+++ b/splinter/driver/webdriver/chrome.py
@@ -6,8 +6,7 @@
 
 from selenium.webdriver import Chrome
 from selenium.webdriver.chrome.options import Options
-from splinter.driver.webdriver import BaseWebDriver, WebDriverElement
-from splinter.driver.webdriver.cookie_manager import CookieManager
+from splinter.driver.webdriver import BaseWebDriver
 
 
 class WebDriver(BaseWebDriver):
@@ -40,10 +39,6 @@ class WebDriver(BaseWebDriver):
             options.add_argument("--headless")
             options.add_argument("--disable-gpu")
 
-        self.driver = Chrome(options=options, **kwargs)
+        driver = Chrome(options=options, **kwargs)
 
-        self.element_class = WebDriverElement
-
-        self._cookie_manager = CookieManager(self.driver)
-
-        super(WebDriver, self).__init__(wait_time)
+        super(WebDriver, self).__init__(driver, wait_time)

--- a/splinter/driver/webdriver/edge.py
+++ b/splinter/driver/webdriver/edge.py
@@ -12,8 +12,7 @@ except ImportError:
     from selenium.webdriver import Edge
     from selenium.webdriver.edge.options import Options
 
-from splinter.driver.webdriver import BaseWebDriver, WebDriverElement
-from splinter.driver.webdriver.cookie_manager import CookieManager
+from splinter.driver.webdriver import BaseWebDriver
 
 
 class WebDriver(BaseWebDriver):
@@ -49,10 +48,6 @@ class WebDriver(BaseWebDriver):
 
         options.use_chromium = chromium
 
-        self.driver = Edge(options=options, **kwargs)
+        driver = Edge(options=options, **kwargs)
 
-        self.element_class = WebDriverElement
-
-        self._cookie_manager = CookieManager(self.driver)
-
-        super(WebDriver, self).__init__(wait_time)
+        super(WebDriver, self).__init__(driver, wait_time)

--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -6,11 +6,7 @@
 
 from selenium.webdriver import Firefox
 from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
-from splinter.driver.webdriver import (
-    BaseWebDriver,
-    WebDriverElement as WebDriverElement,
-)
-from splinter.driver.webdriver.cookie_manager import CookieManager
+from splinter.driver.webdriver import BaseWebDriver
 from selenium.webdriver.firefox.options import Options
 
 
@@ -56,7 +52,7 @@ class WebDriver(BaseWebDriver):
         if incognito:
             options.add_argument("-private")
 
-        self.driver = Firefox(
+        driver = Firefox(
             firefox_profile,
             options=options,
             **kwargs,
@@ -64,13 +60,9 @@ class WebDriver(BaseWebDriver):
 
         if extensions:
             for extension in extensions:
-                self.driver.install_addon(extension)
+                driver.install_addon(extension)
 
         if fullscreen:
-            self.driver.fullscreen_window()
+            driver.fullscreen_window()
 
-        self.element_class = WebDriverElement
-
-        self._cookie_manager = CookieManager(self.driver)
-
-        super(WebDriver, self).__init__(wait_time)
+        super(WebDriver, self).__init__(driver, wait_time)

--- a/splinter/driver/webdriver/remote.py
+++ b/splinter/driver/webdriver/remote.py
@@ -7,11 +7,8 @@
 from selenium.webdriver import Remote
 from selenium.webdriver.remote import remote_connection
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
-from splinter.driver.webdriver import (
-    BaseWebDriver,
-    WebDriverElement,
-)
-from splinter.driver.webdriver.cookie_manager import CookieManager
+
+from splinter.driver.webdriver import BaseWebDriver
 from splinter.driver.webdriver.remote_connection import patch_request
 
 # MonkeyPatch RemoteConnection
@@ -44,10 +41,6 @@ class WebDriver(BaseWebDriver):
 
         kwargs['desired_capabilities'] = caps
 
-        self.driver = Remote(command_executor, **kwargs)
+        driver = Remote(command_executor, **kwargs)
 
-        self.element_class = WebDriverElement
-
-        self._cookie_manager = CookieManager(self.driver)
-
-        super(WebDriver, self).__init__(wait_time)
+        super(WebDriver, self).__init__(driver, wait_time)


### PR DESCRIPTION
This PR simplifies how the Chrome, Firefox, and Remote classes inherit from BaseWebDriver. It is now possible to use BaseWebDriver directly.

This does not impact the ability to override element_class or _cookie_manager in the future, if necessary.