### PR TITLE
Add support for Microsoft Edge

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,41 @@
+name: CI-Windows
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        include:
+          - PY_VER: py27
+            python-version: 2.7
+          - PY_VER: py39
+            python-version: 3.9
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{matrix.python-version}}
+
+      - name: Install test dependencies
+        run: pip install tox
+
+      - name: Set env
+        run: echo "DISPLAY=:99.0" >> $GITHUB_ENV
+
+      - name: Run tests for windows-only drivers
+        run: |
+          tox -e tests_windows -- -n 4 tests/test_webdriver.py tests/test_popups.py tests/test_webdriver_edge_chromium.py;

--- a/docs/drivers/edge.rst
+++ b/docs/drivers/edge.rst
@@ -1,0 +1,151 @@
+.. Copyright 2021 splinter authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the LICENSE file.
+
+.. meta::
+    :description: How to use splinter with Edge WebDriver
+    :keywords: splinter, python, tutorial, how to install, installation, edge, selenium
+
+++++++++++++++
+Edge WebDriver
+++++++++++++++
+
+Installation
+------------
+
+Microsoft Edge has extra requirements:
+
+    - `msedge-selenium-tools <https://github.com/microsoft/edge-selenium-tools>`_
+
+Using pip, they can be installed automatically:
+
+.. code-block:: console
+
+    pip install splinter[edge]
+
+The following applications are also required:
+
+  - `Microsoft Edge <https://www.microsoft.com/edge>`_
+  - `Microsoft Edge Driver <https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/>`_
+
+Microsoft Edge Driver must also be available on your operating system's `PATH` environment variable.
+
+Mac OS X
+++++++++
+
+Modern versions of Edge (79+) are available for Mac OS X.
+However, no versions of Edge Legacy are available.
+
+
+Linux
++++++
+
+Neither version of Edge is available for Linux, and thus Edge WebDriver
+cannot be used on Linux systems.
+
+
+Usage
+-----
+
+To use the Edge driver, pass the string ``edge`` when you create
+the ``Browser`` instance:
+
+.. code-block:: python
+
+    from splinter import Browser
+    browser = Browser('edge')
+
+Edge Options
+++++++++++++
+
+Selenium Options can be passed to customize Edge's behaviour through the
+``EdgeOptions`` object
+
+It must be imported from the ``msedge-selenium-tools`` package.
+
+.. code-block:: python
+
+    from msedge.selenium_tools import EdgeOptions
+    from splinter import Browser
+
+    mobile_emulation = {"deviceName": "Google Nexus 5"}
+    edge_options = EdgeOptions()
+    browser = Browser('edge', options=edge_options)
+
+Headless mode
++++++++++++++
+
+To use headless mode, pass the `headless` argument
+when creating a new Browser instance.
+
+.. code-block:: python
+
+    from splinter import Browser
+    browser = Browser('edge', headless=True)
+
+Incognito mode
+++++++++++++++
+
+To use Edge's incognito mode, pass the `incognito` argument
+when creating a Browser instance.
+
+.. code-block:: python
+
+    from splinter import Browser
+    browser = Browser('edge', incognito=True)
+
+Emulation mode
+++++++++++++++
+
+Since Selenium options can be passed to customize Edge's behaviour;
+it is then possible to leverage the experimental emulation mode.
+
+.. code-block:: python
+
+    from msedge.selenium_tools import EdgeOptions
+    from splinter import Browser
+
+    mobile_emulation = {"deviceName": "Google Nexus 5"}
+    edge_options = EdgeOptions()
+    edge_options.add_experimental_option(
+      "mobileEmulation", mobile_emulation,
+    )
+    browser = Browser('edge', options=edge_options)
+
+Custom executable path
+++++++++++++++++++++++
+
+Edge can also be used from a custom path.
+Pass the executable path as a dictionary to the `**kwargs` argument.
+The dictionary should be set up with `executable_path` as the key and
+the value set to the path to the executable file.
+
+.. code-block:: python
+
+    from splinter import Browser
+    executable_path = {'executable_path':'</path/to/edge>'}
+
+    browser = Browser('edge', **executable_path)
+
+Edge Legacy
++++++++++++
+
+By default, Edge WebDriver is configured to use versions of Edge built with
+Chromium (Version 79 and up).
+
+To use Edge Legacy, pass the `chromium` argument when creating a new Browser
+instance.
+
+This requires the correct version of Edge and Edge Driver to be installed.
+
+.. code-block:: python
+
+    from splinter import Browser
+    browser = Browser('edge', chromium=False)
+
+API docs
+--------
+
+.. autoclass:: splinter.driver.webdriver.edge.WebDriver
+   :members:
+   :inherited-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -150,6 +150,7 @@ Get in touch and contribute
 
    drivers/chrome
    drivers/firefox
+   drivers/edge
    drivers/remote
    drivers/zope.testbrowser
    drivers/django

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -3,3 +3,4 @@ sphinx-rtd-theme>=0.1.8
 cssselect>=1.0.3
 lxml==4.6.3
 zope.testbrowser==5.5.1
+msedge-selenium-tools==3.141.3

--- a/requirements/test_windows.txt
+++ b/requirements/test_windows.txt
@@ -1,0 +1,12 @@
+selenium==3.141.0
+coverage==5.5
+argparse
+Flask==1.1.2
+Pillow==6.2.2; python_version < '3.5'
+Pillow==8.3.1; python_version >= '3.5'
+pytest==4.6.9; python_version < '3.0'
+pytest==6.2.4; python_version >= '3.0'
+pytest-xdist==1.34.0; python_version < '3.0'
+pytest-xdist==2.3.0; python_version >= '3.0'
+six==1.16.0
+msedge-selenium-tools==3.141.3

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "zope.testbrowser": ["zope.testbrowser>=5.2.4", "lxml>=4.2.4", "cssselect"],
         "django": ["Django>=1.7.11", "lxml>=2.3.6", "cssselect", "six"],
         "flask": ["Flask>=1.0.2", "lxml>=2.3.6", "cssselect"],
+        "edge": ["msedge-selenium-tools"],
     },
     tests_require=["coverage", "flask"],
 )

--- a/splinter/browser.py
+++ b/splinter/browser.py
@@ -27,6 +27,14 @@ _DRIVERS = {
 
 
 try:
+    from splinter.driver.webdriver.edge import WebDriver as EdgeWebDriver
+
+    _DRIVERS["edge"] = EdgeWebDriver
+except ImportError:
+    pass
+
+
+try:
     from splinter.driver.zopetestbrowser import ZopeTestBrowser
 
     _DRIVERS["zope.testbrowser"] = ZopeTestBrowser

--- a/splinter/driver/webdriver/edge.py
+++ b/splinter/driver/webdriver/edge.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2021 splinter authors. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from msedge.selenium_tools import Edge, EdgeOptions
+from splinter.driver.webdriver import BaseWebDriver, WebDriverElement
+from splinter.driver.webdriver.cookie_manager import CookieManager
+
+
+class WebDriver(BaseWebDriver):
+
+    driver_name = "Edge"
+
+    def __init__(
+        self,
+        options=None,
+        user_agent=None,
+        wait_time=2,
+        fullscreen=False,
+        incognito=False,
+        headless=False,
+        chromium=True,
+        **kwargs
+    ):
+
+        options = EdgeOptions() or options
+
+        if user_agent is not None:
+            options.add_argument("--user-agent=" + user_agent)
+
+        if incognito:
+            options.add_argument("--incognito")
+
+        if fullscreen:
+            options.add_argument("--kiosk")
+
+        if headless:
+            options.add_argument("--headless")
+            options.add_argument("--disable-gpu")
+
+        options.use_chromium = chromium
+
+        self.driver = Edge(options=options, **kwargs)
+
+        self.element_class = WebDriverElement
+
+        self._cookie_manager = CookieManager(self.driver)
+
+        super(WebDriver, self).__init__(wait_time)

--- a/tests/base.py
+++ b/tests/base.py
@@ -4,6 +4,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 import time
+import os
 from six.moves.urllib import parse
 
 import pytest
@@ -36,6 +37,7 @@ def get_browser(browser_name, **kwargs):
             kwargs['fullscreen'] = True
         options = webdriver.chrome.options.Options()
         options.add_argument("--disable-dev-shm-usage")
+
         return Browser(
             "chrome",
             headless=True,
@@ -70,6 +72,14 @@ def get_browser(browser_name, **kwargs):
 
     elif browser_name == 'zope.testbrowser':
         return Browser("zope.testbrowser", wait_time=0.1)
+
+    elif browser_name == 'edge':
+        # Github Actions Windows EdgeDriver path
+        driver_path = os.getenv('EDGEWEBDRIVER')
+        if driver_path:
+            kwargs['executable_path'] = driver_path + '\msedgedriver.exe'  # NOQA
+
+        return Browser('edge', headless=True, **kwargs)
 
     raise ValueError('Unknown browser name')
 

--- a/tests/fake_webapp.py
+++ b/tests/fake_webapp.py
@@ -8,8 +8,8 @@ from functools import wraps
 from io import open
 from os import path
 
-
 from flask import Flask, request, abort, Response, redirect, url_for
+
 
 this_folder = path.abspath(path.dirname(__file__))
 

--- a/tests/test_popups.py
+++ b/tests/test_popups.py
@@ -4,6 +4,8 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+import platform
+
 from .base import get_browser
 from .fake_webapp import EXAMPLE_APP
 
@@ -13,6 +15,9 @@ import pytest
 supported_browsers = [
     'chrome', 'firefox', 'chrome_fullscreen', 'firefox_fullscreen',
 ]
+
+if platform.system() == 'Windows':
+    supported_browsers = ['edge']
 
 
 @pytest.fixture

--- a/tests/test_webdriver.py
+++ b/tests/test_webdriver.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 from .base import get_browser
 from .fake_webapp import EXAMPLE_APP
@@ -7,6 +8,9 @@ import pytest
 
 
 supported_browsers = ['chrome', 'firefox']
+
+if platform.system() == 'Windows':
+    supported_browsers = ['edge']
 
 
 @pytest.mark.parametrize('browser_name', supported_browsers)
@@ -33,4 +37,10 @@ def test_attach_file(request, browser_name):
 @pytest.mark.parametrize('browser_name', supported_browsers)
 def test_should_support_with_statement(browser_name):
     with get_browser(browser_name):
+        pass
+
+
+@pytest.mark.parametrize('browser_name', supported_browsers)
+def test_should_support_with_statement_fullscreen(browser_name):
+    with get_browser(browser_name, fullscreen=True):
         pass

--- a/tests/test_webdriver_edge_chromium.py
+++ b/tests/test_webdriver_edge_chromium.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2013 splinter authors. All rights reserved.
+# Copyright 2021 splinter authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -12,10 +12,10 @@ from .fake_webapp import EXAMPLE_APP
 from .base import WebDriverTests, get_browser
 
 
-class ChromeBrowserTest(WebDriverTests, unittest.TestCase):
+class EdgeChromiumBrowserTest(WebDriverTests, unittest.TestCase):
     @pytest.fixture(autouse=True, scope='class')
     def setup_browser(self, request):
-        request.cls.browser = get_browser('chrome', fullscreen=False)
+        request.cls.browser = get_browser('edge', fullscreen=False)
         request.addfinalizer(request.cls.browser.quit)
 
     @pytest.fixture(autouse=True)
@@ -24,10 +24,10 @@ class ChromeBrowserTest(WebDriverTests, unittest.TestCase):
         self.browser.visit(EXAMPLE_APP)
 
 
-class ChromeBrowserFullscreenTest(WebDriverTests, unittest.TestCase):
+class EdgeChromiumBrowserFullscreenTest(WebDriverTests, unittest.TestCase):
     @pytest.fixture(autouse=True, scope='class')
     def setup_browser(self, request):
-        request.cls.browser = get_browser('chrome', fullscreen=True)
+        request.cls.browser = get_browser('edge', fullscreen=True)
         request.addfinalizer(request.cls.browser.quit)
 
     @pytest.fixture(autouse=True)

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,16 @@ deps = -rrequirements/test.txt
 commands=
     pytest -v {posargs}
 
+
+[testenv:tests_windows]
+deps =
+  -rrequirements\test_windows.txt
+passenv =
+  EDGEWEBDRIVER
+commands=
+    pytest -v {posargs}
+
+
 [testenv:lint]
 deps = -rrequirements/lint.txt
 commands = flake8


### PR DESCRIPTION
- Separate Github Actions Workflow for running Edge tests on Windows.
- Use Microsoft's implementation of Edge WebDriver for Selenium 3 compatibility.
- Edge Legacy is untested, but available to toggle on since Selenium supports it.