### PR TITLE
Pin Selenium

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     + [("Programming Language :: Python :: %s" % x) for x in "2.7 3.6 3.7 3.8 3.9".split()],
     packages=find_packages(exclude=["docs", "tests", "samples"]),
     include_package_data=True,
-    install_requires=["selenium>=3.141.0", "six"],
+    install_requires=["selenium>=3.141.0,<4.0", "six"],
     extras_require={
         "zope.testbrowser": ["zope.testbrowser>=5.2.4", "lxml>=4.2.4", "cssselect"],
         "django": ["Django>=1.7.11", "lxml>=2.3.6", "cssselect", "six"],


### PR DESCRIPTION
Selenium 4.0.0 was just released.
With the latest version there's apparently some API changes that Splinter doesn't handle well.

Our issue was `TypeError: __init__() got an unexpected keyword argument 'timeout'` on https://github.com/cobrateam/splinter/blob/253a6f21699a60651943bac11cf87a24da4d5a81/splinter/driver/webdriver/firefox.py#L71

As a workaround for now, until #929 gets properly fixed, we can probably pin the version of Selenium as a dependency to be lower than 4.0.