### PR TITLE
Deprecate browser-level fill(), type(), check(), uncheck()

### DIFF
--- a/splinter/driver/__init__.py
+++ b/splinter/driver/__init__.py
@@ -252,6 +252,32 @@ class DriverAPI(InheritedDocs("_DriverAPI", (object,), {})):  # type: ignore
             "%s doesn't support finding options by text." % self.driver_name,
         )
 
+    def set_find_strategy(self, strategy):
+        """Change the strategy used by browser.find().
+
+        Arguments:
+            strategy (str): The strategy used for finding elements. Can be one of either:
+                'css', 'name', 'xpath'
+
+        Returns:
+            Browser: The current browser instance
+        """
+        raise NotImplementedError(f"{self.driver_name} doesn't support set_find_strategy()")
+
+    def find(self, locator):
+        """Find an element.
+
+        The default strategy used is 'name'. To change the strategy, see:
+        browser.set_find_strategy()
+
+        Arguments:
+            locator (str): The string used to locate an element.
+
+        Returns:
+            The found element
+        """
+        raise NotImplementedError(f"{self.driver_name} doesn't support find()")
+
     def is_text_present(self, text: str, wait_time: Optional[int] = None) -> bool:
         """Check if a piece of text is on the page.
 


### PR DESCRIPTION
Solution for:
#8
#162
#684

This PR adds a generic find method to replace the browser level actions. Currently it uses name, so the following are equivalent:
```
browser.fill('v', 'my_text')
```
```
browser.find('v').fill('my_text')
```

In 2021, find_by_name is significantly less useful than css or xpath. By exposing a generic find with an API for controlling which strategy is used, the browser level methods become unnecessary, but the shorthand style of writing scripts is preserved and made relevant for more people, eg:

```
browser.set_find_strategy('css')
browser.find('.my_css').click()
browser.find('.another_css').fill('some_text')
```

This also removes any need to deprecate find_by_x methods.

Roadmap:
#933
- Deprecate browser level actions
- Add generic find() method, defaults to find_by_name
- Add set_find_strategy() method to set find method. Allow name, xpath, css

Future:
- Remove browser level actions
- Default generic find to xpath, remove name
- Update documentation
- Write find() method tutorial