### PR TITLE
Update index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ Sample code
         browser.visit(url)
         browser.fill('q', 'splinter - python acceptance testing for web applications')
         # Find and click the 'search' button
-        button = browser.find_by_name('btnG')
+        button = browser.find_by_value('Google Search')
         # Interact with elements
         button.click()
         if browser.is_text_present('splinter.readthedocs.io'):


### PR DESCRIPTION
The name='btnG' does not exist on "http://www.google.com" and a run of the sample code results in an IndexError exception.  I propose that the button be accessed by value='Google Search' as this will make the sample code work and will be more resilient to change than continuing to use the often-changing Google element names.