### PR TITLE
Fixed Error in Sample code of Splinter Documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,19 +21,17 @@ Sample code
 
     from splinter import Browser
 
-    with Browser() as browser:
-        # Visit URL
-        url = "http://www.google.com"
-        browser.visit(url)
-        browser.fill('q', 'splinter - python acceptance testing for web applications')
-        # Find and click the 'search' button
-        button = browser.find_by_name('btnG')
-        # Interact with elements
-        button.click()
-        if browser.is_text_present('splinter.readthedocs.io'):
-            print("Yes, the official website was found!")
-        else:
-            print("No, it wasn't found... We need to improve our SEO techniques")
+    browser = Browser()
+    browser.visit('http://google.com')
+    browser.fill('q', 'splinter - python acceptance testing for web applications')
+    browser.find_by_name('btnK').click()
+
+    if browser.is_text_present('splinter.readthedocs.io'):
+        print("Yes, the official website was found!")
+    else:
+        print("No, it wasn't found... We need to improve our SEO techniques")
+
+    browser.quit()
 
 **Note:** if you don't provide any driver to the ``Browser`` function, ``firefox`` will be used.
 


### PR DESCRIPTION
The Documentation wasn't updated according to the change in Google Search page. In the Documentation, the Google search  button was addressed by the name `btnG`. But it was modified to `btnK` by Google. This was rectified in the GIithub `Readme` file. But not in the official documentation. So I replaced the code from `Readme` to Documentation `index` file.

Linked to issue #945