### PR TITLE
Remove python 2.7 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - PY_VER: py27
-            python-version: 2.7
           - PY_VER: py36
             python-version: 3.6
           - PY_VER: py37

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,8 +16,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - PY_VER: py27
-            python-version: 2.7
+          - PY_VER: py36
+            python-version: 3.6
+          - PY_VER: py37
+            python-version: 3.7
+          - PY_VER: py38
+            python-version: 3.8
           - PY_VER: py39
             python-version: 3.9
 

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,7 +1,5 @@
-flake8==3.9.2; python_version < '3.6'
 flake8==4.0.1; python_version >= '3.6'
 flake8-comprehensions==3.7.0; python_version >= '3.0'
-flake8-comprehensions==1.4.1; python_version < '3.0'
 flake8-multiline-containers==0.0.18; python_version >= '3.6'
 flake8-mutable==1.2.0
 mccabe==0.6.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,20 +1,12 @@
 zope.testbrowser==5.5.1
 lxml==4.6.4
-Flask==1.1.4; python_version < '3.6'
 Flask==2.0.2; python_version >= '3.6'
 selenium==3.141.0
-coverage==5.5; python_version < '3.6'
 coverage==6.0.2; python_version >= '3.6'
 cssselect>=1.0.3
 argparse
-Django>=1.7.11; python_version < '3.0'
 Django>=2.0.6; python_version >= '3.0'
-Pillow==6.2.2; python_version < '3.5'
 Pillow==8.4.0; python_version >= '3.5'
-pytest==4.6.9; python_version < '3.0'
 pytest==6.2.5; python_version >= '3.0'
-pytest-xdist==1.34.0; python_version < '3.0'
 pytest-xdist==2.4.0; python_version >= '3.0'
-six==1.16.0
-twine<2; python_version < '3.0'
 twine==3.7.0; python_version >= '3.0'

--- a/requirements/test_windows.txt
+++ b/requirements/test_windows.txt
@@ -1,13 +1,8 @@
 selenium==3.141.0
 coverage==5.5
 argparse
-Flask==1.1.4; python_version < '3.6'
 Flask==2.0.2; python_version >= '3.6'
-Pillow==6.2.2; python_version < '3.5'
 Pillow==8.4.0; python_version >= '3.5'
-pytest==4.6.9; python_version < '3.0'
 pytest==6.2.5; python_version >= '3.0'
-pytest-xdist==1.34.0; python_version < '3.0'
 pytest-xdist==2.4.0; python_version >= '3.0'
-six==1.16.0
 msedge-selenium-tools==3.141.3

--- a/setup.py
+++ b/setup.py
@@ -20,17 +20,16 @@ setup(
     license="BSD",
     classifiers=[
         "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
     ]
-    + [("Programming Language :: Python :: %s" % x) for x in "2.7 3.6 3.7 3.8 3.9".split()],
+    + [("Programming Language :: Python :: %s" % x) for x in "3.6 3.7 3.8 3.9".split()],
     packages=find_packages(exclude=["docs", "tests", "samples"]),
     include_package_data=True,
-    install_requires=["selenium>=3.141.0,<4.0", "six"],
+    install_requires=["selenium>=3.141.0,<4.0"],
     extras_require={
-        "zope.testbrowser": ["zope.testbrowser>=5.2.4", "lxml>=4.2.4", "cssselect"],
-        "django": ["Django>=1.7.11", "lxml>=2.3.6", "cssselect", "six"],
-        "flask": ["Flask>=1.0.2", "lxml>=2.3.6", "cssselect"],
+        "zope.testbrowser": ["zope.testbrowser>=5.5.1", "lxml>=4.2.4", "cssselect"],
+        "django": ["Django>=2.0.6", "lxml>=4.2.4", "cssselect"],
+        "flask": ["Flask>=2.0.2", "lxml>=4.2.4", "cssselect"],
         "edge": ["msedge-selenium-tools"],
     },
     tests_require=["coverage", "flask"],

--- a/splinter/browser.py
+++ b/splinter/browser.py
@@ -4,10 +4,8 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-try:
-    from httplib import HTTPException
-except ImportError:
-    from http.client import HTTPException
+
+from http.client import HTTPException
 
 from urllib3.exceptions import MaxRetryError
 

--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -4,8 +4,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-import six
-from six.moves.urllib import parse
+from urllib import parse
 
 from splinter.cookie_manager import CookieManagerAPI
 from splinter.request_handler.status_code import StatusCode
@@ -64,7 +63,7 @@ class DjangoClient(LxmlDriver):
         self._custom_headers = kwargs.pop("custom_headers", {})
 
         client_kwargs = {}
-        for key, value in six.iteritems(kwargs):
+        for key, value in kwargs.items():
             if key.startswith("client_"):
                 client_kwargs[key.replace("client_", "")] = value
 

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -4,11 +4,8 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-try:
-    from urllib.parse import parse_qs, urlparse, urlencode, urlunparse
-except ImportError:
-    from urlparse import parse_qs, urlparse, urlunparse
-    from urllib import urlencode
+
+from urllib.parse import parse_qs, urlparse, urlencode, urlunparse
 
 from splinter.cookie_manager import CookieManagerAPI
 from splinter.request_handler.status_code import StatusCode

--- a/splinter/driver/lxmldriver.py
+++ b/splinter/driver/lxmldriver.py
@@ -6,11 +6,9 @@
 
 import re
 import time
-import sys
 import warnings
 
-import six
-from six.moves.urllib import parse
+from urllib import parse
 
 import lxml.etree
 import lxml.html
@@ -468,11 +466,6 @@ class LxmlControlElement(LxmlElement):
 
     def fill(self, value):
         parent_form = self._get_parent_form()
-
-        if not sys.version_info[0] > 2:
-            if not isinstance(value, six.text_type):
-                value = value.decode("utf-8")
-
         parent_form.fields[self["name"]] = value
 
     def select(self, value):

--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -26,8 +26,6 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions as EC  # NOQA: N812
 from selenium.webdriver.support.ui import WebDriverWait
 
-from six import BytesIO
-
 from splinter.driver import DriverAPI, ElementAPI
 from splinter.driver.find_links import FindLinks
 from splinter.driver.xpath_utils import _concat_xpath_from_str
@@ -1011,7 +1009,7 @@ class WebDriverElement(ElementAPI):
 
         full_screen_png = self.driver.get_screenshot_as_png()
 
-        full_screen_bytes = BytesIO(full_screen_png)
+        full_screen_bytes = io.BytesIO(full_screen_png)
 
         im = Image.open(full_screen_bytes)
         im_width, im_height = im.size[0], im.size[1]

--- a/splinter/driver/webdriver/remote_connection.py
+++ b/splinter/driver/webdriver/remote_connection.py
@@ -1,9 +1,5 @@
 import socket
-
-try:
-    from httplib import HTTPException
-except ImportError:
-    from http.client import HTTPException
+from http.client import HTTPException
 
 import urllib3
 from urllib3.exceptions import MaxRetryError

--- a/tests/base.py
+++ b/tests/base.py
@@ -5,7 +5,7 @@
 # license that can be found in the LICENSE file.
 import time
 import os
-from six.moves.urllib import parse
+from urllib import parse
 
 import pytest
 from selenium import webdriver

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,7 @@ import os
 
 from multiprocessing import Process
 
-try:
-    from urllib import urlopen
-except ImportError:
-    from urllib.request import urlopen
+from urllib.request import urlopen
 
 from tests.fake_webapp import start_flask_app, EXAMPLE_APP
 

--- a/tests/fake_django/urls.py
+++ b/tests/fake_django/urls.py
@@ -1,14 +1,9 @@
-from django.conf.urls import include, url
+from django.conf.urls import url
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.contrib import admin
 from django.contrib.auth.decorators import login_required
-import six
-
-if six.PY2:
-    from django.core.urlresolvers import reverse
-else:
-    from django.urls import reverse
+from django.urls import reverse
 
 from tests.fake_webapp import (
     EXAMPLE_HTML,
@@ -60,7 +55,7 @@ def post_form(request):
 
 def request_headers(request):
     body = "\n".join(
-        "%s: %s" % (key, value) for key, value in six.iteritems(request.META)
+        "%s: %s" % (key, value) for key, value in request.META.items()
     )
     return HttpResponse(body)
 
@@ -123,7 +118,4 @@ urlpatterns = [
     url(r"^redirect-location", redirect_location, name="redirect_location"),
 ]
 
-if six.PY2:
-    urlpatterns.append(url(r"^admin/", include(admin.site.urls)))
-else:
-    urlpatterns.append(url(r"^admin/", admin.site.urls))
+urlpatterns.append(url(r"^admin/", admin.site.urls))

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4,12 +4,10 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-try:
-    import __builtin__ as builtins
-except ImportError:
-    import builtins
+
+import builtins
 import unittest
-from imp import reload
+from importlib import reload
 
 from splinter.exceptions import DriverNotFoundError
 

--- a/tests/test_djangoclient.py
+++ b/tests/test_djangoclient.py
@@ -8,7 +8,7 @@ import os
 import sys
 import time
 import unittest
-from six.moves.urllib import parse
+from urllib import parse
 
 import django
 from splinter import Browser

--- a/tests/test_webdriver_remote.py
+++ b/tests/test_webdriver_remote.py
@@ -4,10 +4,8 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-try:
-    from urllib import urlopen
-except ImportError:
-    from urllib.request import urlopen
+
+from urllib.request import urlopen
 import unittest
 
 from splinter import Browser

--- a/tests/test_zopetestbrowser.py
+++ b/tests/test_zopetestbrowser.py
@@ -7,8 +7,6 @@
 import os
 import unittest
 
-import six
-
 import pytest
 
 from splinter import Browser
@@ -157,7 +155,7 @@ class ZopeTestBrowserDriverTest(
             "pangram_ru": u"В чащах юга жил бы цитрус? Да, но фальшивый экземпляр!",
             "pangram_eo": u"Laŭ Ludoviko Zamenhof bongustas freŝa ĉeĥa manĝaĵo kun spicoj.",
         }
-        for key, text in six.iteritems(non_ascii_encodings):
+        for key, text in non_ascii_encodings.items():
             link = self.browser.find_link_by_text(text)
             self.assertEqual(key, link["id"])
 


### PR DESCRIPTION
It's time.

- Python 2.7 has been pining for the fjords for almost 2 years.
- According to pypistats, only around 8% of downloads are from 2.7 users.
- Selenium 4 isn't compatible with Python 2.7