### PR TITLE
fix: element screenshots gets resized before cropping - cropping out too much of the image

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -1007,18 +1007,9 @@ class WebDriverElement(ElementAPI):
                                       'Please use "pip install Pillow" install it.')
 
         full_screen_png = self.driver.get_screenshot_as_png()
-
         full_screen_bytes = io.BytesIO(full_screen_png)
 
         im = Image.open(full_screen_bytes)
-        im_width, im_height = im.size[0], im.size[1]
-        window_size = self.driver.get_window_size()
-        window_width = window_size['width']
-
-        ratio = im_width * 1.0 / window_width
-        height_ratio = im_height / ratio
-
-        im = im.resize((int(window_width), int(height_ratio)))
 
         location = self._element.location
         x, y = location['x'], location['y']


### PR DESCRIPTION
This may have been a legacy requirement, but gives the wrong results with both the Chrome and Firefox drivers currently. The screenshot gets scaled wider than necessary, leaving a slightly blurred and cut element.

This simply removes the resizing code as explained in #668.

Closes #668.