### PR TITLE
Remove mccabe from requirements

### DIFF
--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -3,5 +3,4 @@ flake8-builtins==1.5.3
 flake8-comprehensions==3.8.0
 flake8-multiline-containers==0.0.18
 flake8-mutable==1.2.0
-mccabe==0.6.1
 pep8-naming==0.12.1


### PR DESCRIPTION
mccabe is a dependency of flake8, no need to specify separately.