### PR TITLE
github/workflows: add workflow for uploading to PyPI

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -1,0 +1,26 @@
+name: Upload to PyPI
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - run: pip install twine
+
+      - run: pip install -e .
+
+      - run: python setup.py sdist bdist_wheel
+
+      - run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -4,6 +4,8 @@ on:
     tags:
       - "*"
 
+  workflow_dispatch:
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -20,7 +22,7 @@ jobs:
 
       - run: python setup.py sdist bdist_wheel
 
-      - run: twine upload dist/*
+      - run: twine upload --skip-existing dist/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -16,18 +16,6 @@ dependencies:
 doc: doc_dependencies
 	@cd docs && make clean && make html
 
-release:
-	@sed -ic -e s/`cat VERSION`/$(version)/ setup.py docs/conf.py splinter/__init__.py
-	@echo $(version) > VERSION
-	@git add setup.py docs/conf.py VERSION splinter/__init__.py
-	@git commit -m "setup: bump to $(version)"
-	@git tag $(version)
-	@git push --tags
-	@git push origin master
-	@rm dist/*
-	@python setup.py sdist bdist_wheel
-	@twine upload dist/*
-
 which = 'tests'
 
 test: dependencies clean


### PR DESCRIPTION
This will happen automatically when we tag the repo.

TODO:

- [ ] Setup a token (preferably with a "bot" account, but I'm happy to generate a splinter-only token with my account)