### PR TITLE
github/workflows/upload-to-pypi: install wheel

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: 3.x
 
-      - run: pip install twine
+      - run: pip install twine wheel
 
       - run: pip install -e .
 


### PR DESCRIPTION
Should fix the workflow.