### PR TITLE
github/workflows: fix selenium-server flakiness

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -31,7 +31,7 @@ jobs:
           - PY_VER: py39
             python-version: 3.9
           - PY_VER: py310
-            python-version: '3.10'
+            python-version: "3.10"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install selenium server
         run: |
-          wget https://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar -O selenium-server.jar
+          wget https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.3.0/selenium-server-4.3.0.jar -O selenium-server.jar
 
       # Lint before running unit tests
       - name: Run lint
@@ -59,7 +59,10 @@ jobs:
       - name: Run Selenium Remote tests
         run: |
           echo "Start Selenium Server"
-          xvfb-run java -jar selenium-server.jar > /dev/null 2>&1 & sleep 3 & tox -e tests -- tests/test_webdriver_remote.py;
+          xvfb-run java -jar selenium-server.jar standalone > selenium-server.log 2>&1 &
+          timeout 30 bash -c 'while ! wget -O /dev/null -T 1 http://localhost:4444/readyz; do echo waiting for selenium server; sleep 1; done' || (cat selenium-server.log && exit 2)
+          echo "Selenium server is ready, running tests"
+          tox -e tests -- tests/test_webdriver_remote.py
 
       - name: Run non-driver tests
         run: |
@@ -82,7 +85,7 @@ jobs:
           - PY_VER: py39
             python-version: 3.9
           - PY_VER: py310
-            python-version: '3.10'
+            python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           echo "Start Selenium Server"
           xvfb-run java -jar selenium-server.jar standalone > selenium-server.log 2>&1 &
-          timeout 30 bash -c 'while ! wget -O /dev/null -T 1 http://localhost:4444/readyz; do echo waiting for selenium server; sleep 1; done' || (cat selenium-server.log && exit 2)
+          timeout 60 bash -c 'while ! wget -O /dev/null -T 1 http://localhost:4444/readyz; do echo waiting for selenium server; sleep 1; done' || (cat selenium-server.log && exit 2)
           echo "Selenium server is ready, running tests"
           tox -e tests -- tests/test_webdriver_remote.py
 


### PR DESCRIPTION
The previous code wasn't doing the right thing: it started the server in
background, slept for 3 seconds in background and started the tests.
Adding another `&` after `sleep 3` would make it actually wait 3
seconds, but instead of doing that we use `timeout` and try the
healthcheck endpoint until the server is ready.

Also upgrade selenium-server.