### PR TITLE
Deprecate using CookieManager.delete() to delete all cookies

### DIFF
--- a/splinter/cookie_manager.py
+++ b/splinter/cookie_manager.py
@@ -44,14 +44,11 @@ class CookieManagerAPI(InheritedDocs("_CookieManagerAPI", (object,), {})):  # ty
 
         You can pass all the cookies identifier that you want to delete.
 
-        If identifiers are provided, all cookies are deleted.
-
         Arguments:
             cookies (list): Identifiers for each cookie to delete.
 
         Examples:
 
-            >>> cookie_manager.delete() # deletes all cookies
             >>> cookie_manager.delete(
                 'name', 'birthday', 'favorite_color') # deletes these three cookies
             >>> cookie_manager.delete('name') # deletes one cookie

--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -4,6 +4,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+import warnings
 from urllib import parse
 
 from splinter.cookie_manager import CookieManagerAPI
@@ -27,6 +28,11 @@ class CookieManager(CookieManagerAPI):
                 except KeyError:
                     pass
         else:
+            warnings.warn(
+                'Deleting all cookies via CookieManager.delete() with no arguments ',
+                'has been deprecated. use CookieManager.delete_all().',
+                FutureWarning,
+            )
             self.delete_all()
 
     def delete_all(self):

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -4,7 +4,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-
+import warnings
 from urllib.parse import parse_qs, urlparse, urlencode, urlunparse
 
 from splinter.cookie_manager import CookieManagerAPI
@@ -29,6 +29,11 @@ class CookieManager(CookieManagerAPI):
                 except KeyError:
                     pass
         else:
+            warnings.warn(
+                'Deleting all cookies via CookieManager.delete() with no arguments ',
+                'has been deprecated. use CookieManager.delete_all().',
+                FutureWarning,
+            )
             self.delete_all()
 
     def delete_all(self):

--- a/splinter/driver/webdriver/cookie_manager.py
+++ b/splinter/driver/webdriver/cookie_manager.py
@@ -3,6 +3,7 @@
 # Copyright 2012 splinter authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
+import warnings
 from urllib.parse import urlparse
 
 from splinter.cookie_manager import CookieManagerAPI
@@ -20,6 +21,11 @@ class CookieManager(CookieManagerAPI):
             for cookie in cookies:
                 self.driver.delete_cookie(cookie)
         else:
+            warnings.warn(
+                'Deleting all cookies via CookieManager.delete() with no arguments ',
+                'has been deprecated. use CookieManager.delete_all().',
+                FutureWarning,
+            )
             self.delete_all()
 
     def delete_all(self):

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 import mimetypes
 import re
 import time
+import warnings
 
 import lxml.html
 from lxml.cssselect import CSSSelector
@@ -40,6 +41,11 @@ class CookieManager(CookieManagerAPI):
                 except KeyError:
                     pass
         else:
+            warnings.warn(
+                'Deleting all cookies via CookieManager.delete() with no arguments ',
+                'has been deprecated. use CookieManager.delete_all().',
+                FutureWarning,
+            )
             self.delete_all()
 
     def delete_all(self):


### PR DESCRIPTION
It's been a while that CookieManager.delete_all() has existed, and that's what the documentation references. Having one method do different things at zero arguments vs one+ arguments was always asking for trouble so it's time to kill it.