### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/news/0.18.1.rst
+++ b/docs/news/0.18.1.rst
@@ -13,5 +13,5 @@ Changed:
 * Set Firefox preferences through options instead of FirefoxProfile
 
 Fixed:
-* Use dedicated logger in browser.py to avoid clobbing other Python logging
+* Use dedicated logger in browser.py to avoid *clobbering* other Python logging
 * Removed required selenium import for error handling, making it possible to use splinter without installing selenium (as long as a selenium driver isn't used)

--- a/docs/news/0.9.0.rst
+++ b/docs/news/0.9.0.rst
@@ -12,7 +12,7 @@ What's New in Splinter 0.9.0?
 * `phantomjs` support was removed (https://github.com/cobrateam/splinter/issues/592)
 * add options argument for chrome driver (https://github.com/cobrateam/splinter/pull/345)
 * (bugfix) avoid element.find_by_text searches whole dom (https://github.com/cobrateam/splinter/issues/612)
-* add suport for zope.testbrowser 5+
+* add support for zope.testbrowser 5+
 * handle webdriver StaleElementReferenceException (https://github.com/cobrateam/splinter/issues/541)
 * add support for Flask 1+
 * add support for selenium 3.14.0

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -93,7 +93,7 @@ class FlaskClient(LxmlDriver):
         self._url = url
         func_method = getattr(self._browser, method.lower())
 
-        # Continue to make requests until a non 30X response is recieved
+        # Continue to make requests until a non 30X response is received
         while True:
             if record_url:
                 self._last_url_index += 1

--- a/tests/is_text_present.py
+++ b/tests/is_text_present.py
@@ -25,7 +25,7 @@ class IsTextPresentTest:
         self.assertTrue(self.browser.is_text_not_present("Text that not exist"))
 
     def test_is_text_not_present_and_should_return_false(self):
-        "should verify if text is not prasent and return false"
+        "should verify if text is not present and return false"
         self.assertFalse(self.browser.is_text_not_present("Example Header"))
 
     def test_is_text_not_present_and_should_wait_time(self):


### PR DESCRIPTION
There are small typos in:
- docs/news/0.18.1.rst
- docs/news/0.9.0.rst
- splinter/driver/flaskclient.py
- tests/is_text_present.py

Fixes:
- Should read `support` rather than `suport`.
- Should read `received` rather than `recieved`.
- Should read `present` rather than `prasent`.
- Should read `*clobbering*` rather than `clobbing`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md