### PR TITLE
Fix attach_file method to FlaskClient

### DIFF
--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -128,6 +128,7 @@ class FlaskClient(LxmlDriver):
 
             # Implement more standard `302`/`303` behaviour
             if self._response.status_code in (302, 303):
+                data = None
                 func_method = getattr(self._browser, "get")
 
             # If the response was not in the `30X` range we're done

--- a/tests/fake_webapp.py
+++ b/tests/fake_webapp.py
@@ -29,6 +29,7 @@ EXAMPLE_NO_BODY_HTML = read_static("no-body.html")
 EXAMPLE_REDIRECT_LOCATION_HTML = read_static("redirect-location.html")
 EXAMPLE_MOUSE_HTML = read_static("mouse.html")
 EXAMPLE_CLICK_INTERCEPTED_HTML = read_static("click_intercepted.html")
+BUFFER = []
 
 # Functions for http basic auth.
 # Taken verbatim from http://flask.pocoo.org/snippets/8/
@@ -110,11 +111,10 @@ def post_form():
 def upload_file():
     if request.method == "POST":
         f = request.files["file"]
-        buffer = [
-            "Content-type: {}".format(f.content_type),
-            "File content: {}".format(f.stream.read()),
-        ]
-        return "|".join(buffer)
+        BUFFER.append("Content-type: {}".format(f.content_type))
+        BUFFER.append("File content: {}".format(f.stream.read()))
+        return redirect(url_for('upload_file'))
+    return "|".join(BUFFER)
 
 
 @app.route("/headers", methods=["GET"])


### PR DESCRIPTION
I recently opened an issue #1080 . When we try to redirect the user to another page, after having sent a file through the form. The following error occurs:

```
ValueError: read of closed file
```

This happens, because, to redirect user for another page using some test client is necessary  ensure that to `GET` the `data` object is not sent.