### PR TITLE
Changed find_by_name to find_by_xpath in fill()

### DIFF
--- a/splinter/driver/webdriver/__init__.py
+++ b/splinter/driver/webdriver/__init__.py
@@ -558,8 +558,8 @@ class BaseWebDriver(DriverAPI):
             wait_time=wait_time,
         )
 
-    def fill(self, name, value):
-        field = self.find_by_name(name).first
+    def fill(self, xpath, value):
+        field = self.find_by_xpath(xpath).first
         field.value = value
 
     attach_file = fill


### PR DESCRIPTION
When dealing with a page where the name is set dynamically we were not able to use fill() or attach_file() as it was accepting name as a parameter, so changed it to xpath as we can always get a xpath which is unique