### PR TITLE
Remove selenium 3 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,62 +47,13 @@ jobs:
 
       - name: Run tests
         run: |
-          tox -e tests -- -n 4 tests/test_browser.py tests/test_element_list.py tests/test_request_handler.py tests/test_xpath_concat.py 
+          tox -e tests -- -n 4 tests/test_browser.py tests/test_element_list.py tests/test_request_handler.py tests/test_xpath_concat.py
 
       - name: Run non-webdriver driver tests
         run: |
           tox -e tests -- -n 4 tests/test_flaskclient.py tests/test_zopetestbrowser.py tests/test_djangoclient.py tests/test_is_element_present_nojs.py
 
-  # This workflow contains a single job called "build"
-  selenium3:
-    # The type of runner that the job will run on
-    # Java, Chrome, chromedriver, Firefox, geckodriver are installed by default on this machine.
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        include:
-          - PY_VER: py37
-            python-version: 3.7
-          - PY_VER: py38
-            python-version: 3.8
-          - PY_VER: py39
-            python-version: 3.9
-          - PY_VER: py310
-            python-version: "3.10"
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{matrix.python-version}}
-
-      - name: Install test dependencies
-        run: pip install tox
-
-      - name: Set env
-        run: echo "DISPLAY=:99.0" >> $GITHUB_ENV
-
-      - name: Install selenium server
-        run: |
-          wget https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.3.0/selenium-server-4.3.0.jar -O selenium-server.jar
-
-      - name: Run Selenium Remote tests
-        run: |
-          echo "Start Selenium Server"
-          xvfb-run java -jar selenium-server.jar standalone > selenium-server.log 2>&1 &
-          timeout 60 bash -c 'while ! wget -O /dev/null -T 1 http://localhost:4444/readyz; do echo waiting for selenium server; sleep 1; done' || (cat selenium-server.log && exit 2)
-          echo "Selenium server is ready, running tests"
-          tox -e tests_selenium3 -- tests/test_webdriver_remote.py
-
-      - name: Run Selenium tests
-        run: |
-          tox -e tests_selenium3 -- -n 4 tests/test_element_is_visible.py tests/test_screenshot.py tests/test_mouse_interaction.py tests/test_async_finder.py tests/test_html_snapshot.py tests/test_iframes.py tests/test_popups.py tests/test_webdriver.py tests/test_webdriver_firefox.py tests/test_webdriver_chrome.py;
-
-  selenium4:
+  selenium:
     runs-on: ubuntu-latest
 
     strategy:
@@ -137,8 +88,11 @@ jobs:
       - name: Run Selenium Remote tests
         run: |
           echo "Start Selenium Server"
-          xvfb-run java -jar selenium-server.jar > /dev/null 2>&1 & sleep 3 & tox -e tests_selenium4 -- tests/test_webdriver_remote.py;
+          xvfb-run java -jar selenium-server.jar standalone > selenium-server.log 2>&1 &
+          timeout 60 bash -c 'while ! wget -O /dev/null -T 1 http://localhost:4444/readyz; do echo waiting for selenium server; sleep 1; done' || (cat selenium-server.log && exit 2)
+          echo "Selenium server is ready, running tests"
+          tox -e tests_selenium -- tests/test_webdriver_remote.py
 
-      - name: Run Selenium 4 tests
+      - name: Run Selenium tests
         run: |
-          tox -e tests_selenium4 -- -n 4 tests/test_element_is_visible.py tests/test_screenshot.py tests/test_shadow_root.py tests/test_mouse_interaction.py tests/test_async_finder.py tests/test_html_snapshot.py tests/test_iframes.py tests/test_popups.py tests/test_webdriver.py tests/test_webdriver_firefox.py tests/test_webdriver_chrome.py;
+          tox -e tests_selenium -- -n 4 tests/test_element_is_visible.py tests/test_screenshot.py tests/test_shadow_root.py tests/test_mouse_interaction.py tests/test_async_finder.py tests/test_html_snapshot.py tests/test_iframes.py tests/test_popups.py tests/test_webdriver.py tests/test_webdriver_firefox.py tests/test_webdriver_chrome.py;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Install selenium server
         run: |
-          wget https://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar -O selenium-server.jar
+          wget https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.3.0/selenium-server-4.3.0.jar -O selenium-server.jar
 
       - name: Run Selenium Remote tests
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  selenium:
     runs-on: windows-latest
 
     strategy:
@@ -42,38 +42,4 @@ jobs:
 
       - name: Run tests for windows-only drivers
         run: |
-          tox -e tests_windows_selenium3 -- -n 4 tests/test_webdriver.py tests/test_popups.py tests/test_webdriver_edge_chromium.py;
-
-  selenium4:
-    runs-on: windows-latest
-
-    strategy:
-      matrix:
-        include:
-          - PY_VER: py37
-            python-version: 3.7
-          - PY_VER: py38
-            python-version: 3.8
-          - PY_VER: py39
-            python-version: 3.9
-          - PY_VER: py310
-            python-version: '3.10'
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{matrix.python-version}}
-
-      - name: Install test dependencies
-        run: pip install tox
-
-      - name: Set env
-        run: echo "DISPLAY=:99.0" >> $GITHUB_ENV
-
-      - name: Run tests for windows-only drivers
-        run: |
-          tox -e tests_windows_selenium4 -- -n 4 tests/test_webdriver.py tests/test_popups.py tests/test_webdriver_edge_chromium.py;
+          tox -e tests_windows_selenium -- -n 4 tests/test_webdriver.py tests/test_popups.py tests/test_webdriver_edge_chromium.py;

--- a/docs/drivers/edge.rst
+++ b/docs/drivers/edge.rst
@@ -28,15 +28,13 @@ Edge Options
 Selenium Options can be passed to customize Edge's behaviour through the
 ``EdgeOptions`` object
 
-It must be imported from the ``msedge-selenium-tools`` package.
-
 .. code-block:: python
 
-    from msedge.selenium_tools import EdgeOptions
+    from selenium.webdriver.edge.options import Options
     from splinter import Browser
 
     mobile_emulation = {"deviceName": "Google Nexus 5"}
-    edge_options = EdgeOptions()
+    edge_options = Options()
     browser = Browser('edge', options=edge_options)
 
 Headless mode
@@ -69,11 +67,11 @@ it is then possible to leverage the experimental emulation mode.
 
 .. code-block:: python
 
-    from msedge.selenium_tools import EdgeOptions
+    from selenium.webdriver.edge.options import Options
     from splinter import Browser
 
     mobile_emulation = {"deviceName": "Google Nexus 5"}
-    edge_options = EdgeOptions()
+    edge_options = Options()
     edge_options.add_experimental_option(
       "mobileEmulation", mobile_emulation,
     )

--- a/docs/install/driver_install.rst
+++ b/docs/install/driver_install.rst
@@ -14,34 +14,16 @@ Drivers
 Selenium-based Drivers
 ======================
 
-To use ``chrome``, ``fireFox``, ``edge``, or ``remote``, the python bindings for Selenium 3 or Selenium 4 must be installed.
+To use ``chrome``, ``fireFox``, ``edge``, or ``remote``, the python bindings for Selenium must be installed.
 
-When splinter is installed via pip, the `selenium3` or `selenium4` extra argument can be provided.
-This will automatically install the latest version of Selenium 3 or Selenium 4, respectively.
-
-
-.. code-block:: bash
-
-    python -m pip install splinter[selenium3]
+When splinter is installed via pip, the `selenium` extra argument can be provided.
+This will automatically install the latest version of Selenium.
 
 
 .. code-block:: bash
 
-    python -m pip install splinter[selenium4]
+    python -m pip install splinter[selenium]
 
-
-Microsoft Edge
-==============
-
-When using Selenium 3, ``edge`` also has the following dependency:
-
-    - `msedge-selenium-tools <https://github.com/microsoft/edge-selenium-tools>`_
-
-Using pip, it can be installed automatically as well:
-
-.. code-block:: bash
-
-    python -m pip install splinter[selenium3, edge]
 
 
 Django

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -13,9 +13,7 @@ Install Splinter
 Basic Requirements
 ==================
 
-Splinter officially supports Python versions 3.6+ for Selenium 3, Django, Flask, and zope.testbrowser.
-
-For Selenium 4, Python versions 3.7+ are supported.
+Splinter officially supports Python versions 3.7 and up.
 
 Latest version via pip
 ======================

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,7 @@ setup(
         "zope.testbrowser": ["zope.testbrowser>=5.5.1", "lxml>=4.2.4", "cssselect"],
         "django": ["Django>=2.0.6", "lxml>=4.2.4", "cssselect"],
         "flask": ["Flask>=2.0.2", "lxml>=4.2.4", "cssselect"],
-        "edge": ["msedge-selenium-tools"],
-        "selenium3": ["selenium>=3.141.0,<4.0"],
-        "selenium4": ["selenium>=4.1.0,<4.2.0"],
+        "selenium": ["selenium>=4.1.0,<4.2.0"],
     },
     tests_require=["coverage", "flask"],
 )

--- a/splinter/driver/webdriver/edge.py
+++ b/splinter/driver/webdriver/edge.py
@@ -4,13 +4,9 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# Selenium 3 compatibility
-try:
-    from msedge.selenium_tools import Edge
-    from msedge.selenium_tools import EdgeOptions as Options
-except ImportError:
-    from selenium.webdriver import Edge
-    from selenium.webdriver.edge.options import Options
+
+from selenium.webdriver import Edge
+from selenium.webdriver.edge.options import Options
 
 from splinter.driver.webdriver import BaseWebDriver
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,32 +11,17 @@ deps = -rrequirements/test.txt
 commands=
     pytest -v {posargs}
 
-[testenv:tests_selenium3]
-extras = selenium3
-deps = -rrequirements/test.txt
-commands=
-    pytest -v {posargs}
 
-[testenv:tests_windows_selenium3]
-extras = selenium3, edge
-deps =
-  -rrequirements\test_windows.txt
-passenv =
-  EDGEWEBDRIVER
-commands=
-    pytest -v {posargs}
-
-
-[testenv:tests_selenium4]
-extras = selenium4
+[testenv:tests_selenium]
+extras = selenium
 deps =
   -rrequirements/test.txt
 commands=
     pytest -v {posargs}
 
 
-[testenv:tests_windows_selenium4]
-extras = selenium4
+[testenv:tests_windows_selenium]
+extras = selenium
 deps =
   -rrequirements\test_windows.txt
 passenv =


### PR DESCRIPTION
The Selenium 3.x series is very dead at this point. For a while it made sense to support it because:

- Selenium 4.0 had deprecation warnings as opposed to removals.
- Splinter did not have to write very much custom code to handle both 3.x and 4.x

Selenium 4.x is moving past these deprecation warnings and it's not worth it to maintain both as a back-end for Splinter as Selenium 4.x continues diverging. At this point, anyone who absolutely needs Selenium 3.x will have to make do with Splinter 0.19.0.