### PR TITLE
Add splinter.Config, deprecate many browser arguments

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,16 @@
+.. Copyright 2023 splinter authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the LICENSE file.
+
+.. meta::
+    :description: Config
+    :keywords: splinter, python, tutorial, config
+
+++++++
+Config
+++++++
+
+.. module:: splinter.config
+
+.. autoclass:: Config
+   :members:

--- a/docs/drivers/chrome.rst
+++ b/docs/drivers/chrome.rst
@@ -26,30 +26,6 @@ the ``Browser`` instance:
 
 **Note:** if you have trouble with ``$HOME/.bash_profile``, you can try ``$HOME/.bashrc``.
 
-Headless mode
-+++++++++++++
-
-Starting with Chrome 59, Chrome can run in a headless mode.
-Further Information: `google developers updates <https://developers.google.com/web/updates/2017/05/nic59#headless>`_
-
-To use headless mode, pass the `headless` argument
-when creating a new Browser instance.
-
-.. code-block:: python
-
-    from splinter import Browser
-    browser = Browser('chrome', headless=True)
-
-Incognito mode
-++++++++++++++
-
-To use Chrome's incognito mode, pass the `incognito` argument
-when creating a Browser instance.
-
-.. code-block:: python
-
-    from splinter import Browser
-    browser = Browser('chrome', incognito=True)
 
 Emulation mode
 ++++++++++++++

--- a/docs/drivers/edge.rst
+++ b/docs/drivers/edge.rst
@@ -37,27 +37,6 @@ Selenium Options can be passed to customize Edge's behaviour through the
     edge_options = Options()
     browser = Browser('edge', options=edge_options)
 
-Headless mode
-+++++++++++++
-
-To use headless mode, pass the `headless` argument
-when creating a new Browser instance.
-
-.. code-block:: python
-
-    from splinter import Browser
-    browser = Browser('edge', headless=True)
-
-Incognito mode
-++++++++++++++
-
-To use Edge's incognito mode, pass the `incognito` argument
-when creating a Browser instance.
-
-.. code-block:: python
-
-    from splinter import Browser
-    browser = Browser('edge', incognito=True)
 
 Emulation mode
 ++++++++++++++

--- a/docs/drivers/firefox.rst
+++ b/docs/drivers/firefox.rst
@@ -24,29 +24,6 @@ the ``Browser`` instance:
 
 **Note:** if you don't provide any driver to ``Browser`` function, ``firefox`` will be used.
 
-Headless mode
-+++++++++++++
-
-Starting with Firefox 55, Firefox can run in a headless mode.
-
-To use headless mode, pass the `headless` argument
-when creating a new Browser instance.
-
-.. code-block:: python
-
-    from splinter import Browser
-    browser = Browser('firefox', headless=True)
-
-Incognito mode
-++++++++++++++
-
-To use Firefox's incognito mode, pass the `incognito` argument
-when creating a Browser instance.
-
-.. code-block:: python
-
-    from splinter import Browser
-    browser = Browser('firefox', incognito=True)
 
 Service
 +++++++
@@ -91,19 +68,6 @@ using the ``profile`` keyword (passing the name of the profile as a ``str`` inst
 
 If you don't specify a profile, a new temporary profile will be created (and deleted when you ``close`` the browser).
 
-Firefox Extensions
-++++++++++++++++++
-
-An extension for firefox is a .xpi archive.
-To use an extension in Firefox webdriver profile you need to give the path of
-the extension, using the extensions keyword (passing the extensions as a ``list`` instance):
-
-.. code-block:: python
-
-    from splinter import Browser
-    browser = Browser('firefox', extensions=['extension1.xpi', 'extension2.xpi'])
-
-After the browser is closed, extensions will be deleted from the profile, even if the profile is not a temporary one.
 
 Selenium Capabilities
 +++++++++++++++++++++

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@
   :hidden:
 
   browser
+  config
   finding
   elements-in-the-page
   mouse-interaction

--- a/splinter/__init__.py
+++ b/splinter/__init__.py
@@ -2,5 +2,12 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from splinter.browser import Browser  # NOQA
+from splinter.browser import Browser
+from splinter.config import Config
 from splinter.version import __version_info__, __version__  # NOQA
+
+
+__all__ = [
+    'Browser',
+    'Config',
+]

--- a/splinter/browser.py
+++ b/splinter/browser.py
@@ -79,7 +79,7 @@ except ImportError as e:
     logger.debug(f'Import Warning: {e}')
 
 
-def get_driver(driver, retry_count=3, *args, **kwargs):
+def get_driver(driver, retry_count=3, config=None, *args, **kwargs):
     """Try to instantiate the driver.
 
     Common selenium errors are caught and a retry attempt occurs.
@@ -90,14 +90,14 @@ def get_driver(driver, retry_count=3, *args, **kwargs):
 
     for _ in range(retry_count):
         try:
-            return driver(*args, **kwargs)
+            return driver(config=config, *args, **kwargs)
         except driver_exceptions as e:
             err = e
 
     raise err
 
 
-def Browser(driver_name: str = "firefox", retry_count: int = 3, *args, **kwargs):  # NOQA: N802
+def Browser(driver_name: str = "firefox", retry_count: int = 3, config=None, *args, **kwargs):  # NOQA: N802
     """Get a new driver instance.
 
     Extra arguments will be sent to the driver instance.
@@ -122,4 +122,4 @@ def Browser(driver_name: str = "firefox", retry_count: int = 3, *args, **kwargs)
     if driver is None:
         raise DriverNotFoundError(f'Driver for {driver_name} was not found.')
 
-    return get_driver(driver, retry_count=retry_count, *args, **kwargs)
+    return get_driver(driver, retry_count=retry_count, config=config, *args, **kwargs)

--- a/splinter/config.py
+++ b/splinter/config.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class Config:
+    """Standard interface for basic and nearly universal driver flags.
+
+    The primary purpose of Config is to reduce the burden on the user to import
+    Selenium Options objects for common operations. The second purpose is to
+    avoid argument bloat and drift for the various drivers.
+
+    Both Splinter Config and Selenium Options can be used together.
+    Config will override Options, if applicable.
+
+    Config is not a complete replacement for Selenium Options.
+    For unique and esoteric functionality that is exclusive to one web browser,
+    Selenium Options should still be used. The purpose of Config is to expose
+    a universal interface for common functionality, not try to capture all
+    of it.
+
+    Example:
+
+        >>> from splinter import Browser, Config
+        >>>
+        >>>
+        >>> my_config = Config(fullscreen=True)
+        >>> my_browser = Browser(config=my_config)
+
+
+    Attributes:
+        extensions: Add extensions to the browser.
+            The full path to each extension must be included.
+            When the browser is closed extensions will be deleted from
+            the profile, even if the profile is not a temporary one.
+
+        fullscreen: Launch the browser in fullscreen mode.
+
+        headless: Launch the browser in headless mode.
+            Requires Chrome 59+ or Firefox 55+.
+
+        incognito: Launch the browser in incognito mode.
+
+        user_agent: Set a custom user_agent.
+    """
+    extensions: Optional[List[str]] = None
+    fullscreen: Optional[bool] = False
+    headless: Optional[bool] = False
+    incognito: Optional[bool] = False
+    user_agent: Optional[str] = ""

--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -3,9 +3,10 @@
 # Copyright 2012 splinter authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-
+from typing import Optional
 from urllib import parse
 
+from splinter.config import Config
 from splinter.cookie_manager import CookieManagerAPI
 from splinter.request_handler.status_code import StatusCode
 
@@ -55,7 +56,13 @@ class DjangoClient(LxmlDriver):
 
     driver_name = "django"
 
-    def __init__(self, user_agent=None, wait_time=2, **kwargs):
+    def __init__(
+        self,
+        user_agent=None,
+        wait_time=2,
+        config: Optional[Config] = None,
+        **kwargs,
+    ):
         from django.test.client import Client
 
         self._custom_headers = kwargs.pop("custom_headers", {})
@@ -66,9 +73,10 @@ class DjangoClient(LxmlDriver):
                 client_kwargs[key.replace("client_", "")] = value
 
         self._browser = Client(**client_kwargs)
-        self._user_agent = user_agent
+
         self._cookie_manager = CookieManager(self._browser)
-        super(DjangoClient, self).__init__(wait_time=wait_time)
+
+        super(DjangoClient, self).__init__(wait_time=wait_time, user_agent=user_agent, config=config)
 
     def __enter__(self):
         return self
@@ -97,7 +105,7 @@ class DjangoClient(LxmlDriver):
             extra.update({"SERVER_NAME": components.hostname})
         if components.port:
             extra.update({"SERVER_PORT": components.port})
-        if self._user_agent:
+        if self.config.user_agent:
             extra.update({"User-Agent": self._user_agent})
         if self._custom_headers:
             extra.update(self._custom_headers)

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -3,9 +3,10 @@
 # Copyright 2014 splinter authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-
+from typing import Optional
 from urllib.parse import parse_qs, urlparse, urlencode, urlunparse
 
+from splinter.config import Config
 from splinter.cookie_manager import CookieManagerAPI
 from splinter.request_handler.status_code import StatusCode
 
@@ -58,7 +59,14 @@ class FlaskClient(LxmlDriver):
 
     driver_name = "flask"
 
-    def __init__(self, app, user_agent=None, wait_time=2, custom_headers=None):
+    def __init__(
+        self,
+        app,
+        user_agent=None,
+        wait_time=2,
+        custom_headers=None,
+        config: Optional[Config] = None,
+    ):
         app.config["TESTING"] = True
         self._browser = app.test_client()
         self._cookie_manager = CookieManager(self._browser)

--- a/splinter/driver/lxmldriver.py
+++ b/splinter/driver/lxmldriver.py
@@ -3,15 +3,17 @@
 # Copyright 2014 splinter authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-
 import re
 import time
 
+from typing import Optional
 from urllib import parse
 
 import lxml.etree
 import lxml.html
 from lxml.cssselect import CSSSelector
+
+from splinter.config import Config
 from splinter.driver import DriverAPI, ElementAPI
 from splinter.driver.find_links import FindLinks
 from splinter.driver.element_present import ElementPresentMixIn
@@ -24,7 +26,12 @@ class LxmlDriver(ElementPresentMixIn, DriverAPI):
     _response = ""
     _url = ""
 
-    def __init__(self, user_agent=None, wait_time=2):
+    def __init__(
+        self,
+        user_agent=None,
+        wait_time=2,
+        config: Optional[Config] = None,
+    ):
         self.wait_time = wait_time
         self._history = []
         self._last_urls = []
@@ -32,6 +39,8 @@ class LxmlDriver(ElementPresentMixIn, DriverAPI):
         self._forms = {}
 
         self.links = FindLinks(self)
+
+        self.config = config or Config(user_agent=user_agent)
 
     def __enter__(self):
         return self

--- a/splinter/driver/webdriver/edge.py
+++ b/splinter/driver/webdriver/edge.py
@@ -10,6 +10,8 @@ from selenium.webdriver import Edge
 from selenium.webdriver.edge.options import Options
 from selenium.webdriver.edge.service import Service
 
+from splinter.config import Config
+from splinter.driver.webdriver.setup import _setup_edge
 from splinter.driver.webdriver import BaseWebDriver
 
 
@@ -27,6 +29,7 @@ class WebDriver(BaseWebDriver):
         headless=False,
         chromium=True,
         service: Optional[Service] = None,
+        config: Optional[Config] = None,
         **kwargs
     ):
 
@@ -44,23 +47,27 @@ class WebDriver(BaseWebDriver):
             else:
                 service.executable_path = kwargs['executable_path']
 
+        if True in [fullscreen, incognito, headless] or user_agent:
+            warnings.warn(
+                (
+                    "Sending fullscreen, incognito, headless, user_agent to the browser object has been deprecated."
+                    "Please pass in a Splinter Config object instead."
+                    "See: https://splinter.readthedocs.io/en/latest/config.html for more details"
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         options = Options() or options
-
-        if user_agent is not None:
-            options.add_argument("--user-agent=" + user_agent)
-
-        if incognito:
-            options.add_argument("--incognito")
-
-        if fullscreen:
-            options.add_argument("--kiosk")
-
-        if headless:
-            options.add_argument("--headless")
-            options.add_argument("--disable-gpu")
-
         options.use_chromium = chromium
 
-        driver = Edge(options=options, service=service, **kwargs)
+        self.config = config or Config(
+            fullscreen=fullscreen,
+            headless=headless,
+            incognito=incognito,
+            user_agent=user_agent,
+        )
+
+        driver = _setup_edge(Edge, config=self.config, options=options, service=service, **kwargs)
 
         super(WebDriver, self).__init__(driver, wait_time)

--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -10,6 +10,8 @@ from selenium.webdriver import Firefox
 from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.firefox.service import Service
 
+from splinter.config import Config
+from splinter.driver.webdriver.setup import _setup_firefox
 from splinter.driver.webdriver import BaseWebDriver
 
 
@@ -30,6 +32,7 @@ class WebDriver(BaseWebDriver):
         headless=False,
         incognito=False,
         service: Optional[Service] = None,
+        config: Optional[Config] = None,
         **kwargs
     ):
 
@@ -47,40 +50,40 @@ class WebDriver(BaseWebDriver):
             else:
                 service.executable_path = kwargs['executable_path']
 
+        if True in [fullscreen, incognito, headless] or user_agent:
+            warnings.warn(
+                (
+                    "Sending fullscreen, incognito, headless, user_agent to the browser object has been deprecated."
+                    "Please pass in a Splinter Config object instead."
+                    "See: https://splinter.readthedocs.io/en/latest/config.html for more details"
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         options = options or Options()
+
         if profile:
             options.set_preference("profile", profile)
         options.set_preference("extensions.logging.enabled", False)
         options.set_preference("network.dns.disableIPv6", False)
 
+        self.config = config or Config(
+            extensions=extensions,
+            fullscreen=fullscreen,
+            headless=headless,
+            incognito=incognito,
+            user_agent=user_agent,
+        )
+
         if capabilities:
             for key, value in capabilities.items():
                 options.set_capability(key, value)
-
-        if user_agent is not None:
-            options.set_preference("general.useragent.override", user_agent)
 
         if profile_preferences:
             for key, value in profile_preferences.items():
                 options.set_preference(key, value)
 
-        if headless:
-            options.add_argument("--headless")
-
-        if incognito:
-            options.add_argument("-private")
-
-        driver = Firefox(
-            options=options,
-            service=service,
-            **kwargs,
-        )
-
-        if extensions:
-            for extension in extensions:
-                driver.install_addon(extension)
-
-        if fullscreen:
-            driver.fullscreen_window()
+        driver = _setup_firefox(Firefox, config=self.config, options=options, service=service, **kwargs)
 
         super(WebDriver, self).__init__(driver, wait_time)

--- a/splinter/driver/webdriver/remote.py
+++ b/splinter/driver/webdriver/remote.py
@@ -3,13 +3,21 @@
 # Copyright 2013 splinter authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
+from typing import Optional
 
 from selenium.webdriver import Remote
 from selenium.webdriver.remote import remote_connection
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
+from splinter.config import Config
+
 from splinter.driver.webdriver import BaseWebDriver
 from splinter.driver.webdriver.remote_connection import patch_request
+from splinter.driver.webdriver.setup import (
+    _setup_chrome,
+    _setup_edge,
+    _setup_firefox,
+)
 
 # MonkeyPatch RemoteConnection
 remote_connection.RemoteConnection._request = patch_request  # type: ignore
@@ -26,7 +34,9 @@ class WebDriver(BaseWebDriver):
         browser="firefox",
         wait_time=2,
         command_executor=DEFAULT_URL,
-        **kwargs
+        options=None,
+        config: Optional[Config] = None,
+        **kwargs,
     ):
         browser_name = browser.upper()
         # Handle case where user specifies IE with a space in it
@@ -41,6 +51,24 @@ class WebDriver(BaseWebDriver):
 
         kwargs['desired_capabilities'] = caps
 
-        driver = Remote(command_executor, **kwargs)
+        kwargs['command_executor'] = command_executor
+
+        self.config = config or Config()
+
+        if browser_name == 'CHROME':
+            from selenium.webdriver.chrome.options import Options
+
+            options = options or Options()
+            driver = _setup_chrome(Remote, self.config, options, **kwargs)
+        elif browser_name == 'EDGE':
+            from selenium.webdriver.edge.options import Options
+
+            options = options or Options()
+            driver = _setup_edge(Remote, self.config, options, **kwargs)
+        elif browser_name == 'FIREFOX':
+            from selenium.webdriver.firefox.options import Options
+
+            options = options or Options()
+            driver = _setup_firefox(Remote, self.config, options, **kwargs)
 
         super(WebDriver, self).__init__(driver, wait_time)

--- a/splinter/driver/webdriver/setup.py
+++ b/splinter/driver/webdriver/setup.py
@@ -1,0 +1,95 @@
+from selenium.webdriver import Remote
+
+"""The following functions prepare Webdriver for use.
+
+Config, Options, Service, and other arguments are configured and sent to
+the driver.
+
+The driver is returned.
+"""
+
+
+def _setup_chrome(driver_class, config=None, options=None, service=None, **kwargs):
+    """
+    Returns: selenium.webdriver.Chrome || selenium.webdriver.Remote
+    """
+    if config.user_agent is not None:
+        options.add_argument(f"--user-agent={config.user_agent}")
+
+    if config.incognito:
+        options.add_argument("--incognito")
+
+    if config.fullscreen:
+        options.add_argument("--kiosk")
+
+    if config.headless:
+        options.add_argument("--headless")
+        options.add_argument("--disable-gpu")
+
+    if config.extensions:
+        for extension in config.extensions:
+            options.add_extension(extension)
+
+    if driver_class == Remote:
+        rv = driver_class(options=options, **kwargs)
+    else:
+        rv = driver_class(options=options, service=service, **kwargs)
+
+    return rv
+
+
+def _setup_edge(driver_class, config=None, options=None, service=None, **kwargs):
+    """
+    Returns: selenium.webdriver.Edge || selenium.webdriver.Remote
+    """
+    if config.user_agent is not None:
+        options.add_argument(f"--user-agent={config.user_agent}")
+
+    if config.incognito:
+        options.add_argument("--incognito")
+
+    if config.fullscreen:
+        options.add_argument("--kiosk")
+
+    if config.headless:
+        options.add_argument("--headless")
+        options.add_argument("--disable-gpu")
+
+    if config.extensions:
+        for extension in config.extensions:
+            options.add_extension(extension)
+
+    if driver_class == Remote:
+        rv = driver_class(options=options, **kwargs)
+    else:
+        rv = driver_class(options=options, service=service, **kwargs)
+
+    return rv
+
+
+def _setup_firefox(driver_class, config=None, options=None, service=None, **kwargs):
+    """
+    Returns: selenium.webdriver.Firefox || selenium.webdriver.Remote
+    """
+    if config.user_agent is not None:
+        options.set_preference("general.useragent.override", config.user_agent)
+
+    if config.headless:
+        options.add_argument("--headless")
+
+    if config.incognito:
+        options.add_argument("-private")
+
+    if driver_class == Remote:
+        rv = driver_class(options=options, **kwargs)
+    else:
+        rv = driver_class(options=options, service=service, **kwargs)
+
+    if config.extensions:
+        for extension in config.extensions:
+            rv.install_addon(extension)
+
+    if config.fullscreen:
+        rv.fullscreen_window()
+
+    return rv

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -10,9 +10,13 @@ import mimetypes
 import re
 import time
 
+from typing import Optional
+
 import lxml.html
 from lxml.cssselect import CSSSelector
 from zope.testbrowser.browser import Browser, ListControl
+
+from splinter.config import Config
 from splinter.element_list import ElementList
 from splinter.exceptions import ElementDoesNotExist
 from splinter.driver import DriverAPI, ElementAPI
@@ -65,7 +69,7 @@ class ZopeTestBrowser(ElementPresentMixIn, DriverAPI):
 
     driver_name = "zope.testbrowser"
 
-    def __init__(self, wait_time=2):
+    def __init__(self, wait_time=2, config: Optional[Config] = None):
         self.wait_time = wait_time
         self._browser = Browser()
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -13,6 +13,7 @@ try:
 except ModuleNotFoundError:
     pass
 
+from splinter.config import Config
 
 from .click_elements import ClickElementsTest
 from .cookies import CookiesTest
@@ -276,11 +277,14 @@ class WebDriverTests(
 
     def test_should_be_able_to_change_user_agent(self):
         driver_name = self.browser.driver_name.lower()
-        browser = get_browser(driver_name, user_agent="iphone")
+
+        config = Config(user_agent="iphone")
+        browser = get_browser(driver_name, config=config)
         browser.visit(EXAMPLE_APP + "useragent")
-        result = "iphone" in browser.html
+
+        assert "iphone" in browser.html
+
         browser.quit()
-        self.assertTrue(result)
 
     def test_execute_script_returns_result_if_present(self):
         assert self.browser.execute_script("return 42") == 42

--- a/tests/get_browser.py
+++ b/tests/get_browser.py
@@ -8,31 +8,35 @@ except ModuleNotFoundError:
     pass
 
 from splinter import Browser
+from splinter.config import Config
 
 from .fake_webapp import app, EXAMPLE_APP
 
 
-def get_browser(browser_name, **kwargs):
+def get_browser(browser_name, config=None, **kwargs):
+    config = config or Config()
+    config.headless = True
+
     if browser_name in ['chrome', 'chrome_fullscreen']:
         if browser_name == 'chrome_fullscreen':
-            kwargs['fullscreen'] = True
+            config.fullscreen = True
         options = webdriver.chrome.options.Options()
         options.add_argument("--disable-dev-shm-usage")
 
         return Browser(
             "chrome",
-            headless=True,
             options=options,
+            config=config,
             **kwargs
         )
 
     elif browser_name in ['firefox', 'firefox_fullscreen']:
         if browser_name == 'firefox_fullscreen':
-            kwargs['fullscreen'] = True
+            config.fullscreen = True
 
         return Browser(
             "firefox",
-            headless=True,
+            config=config,
             **kwargs
         )
 
@@ -62,6 +66,6 @@ def get_browser(browser_name, **kwargs):
             from selenium.webdriver.edge.service import Service as EdgeService
             service = EdgeService(executable_path=f'{driver_path}\msedgedriver.exe')  # NOQA
 
-        return Browser('edge', headless=True, service=service, **kwargs)
+        return Browser('edge', service=service, config=config, **kwargs)
 
     raise ValueError('Unknown browser name')

--- a/tests/test_webdriver.py
+++ b/tests/test_webdriver.py
@@ -53,3 +53,15 @@ def test_attach_file(request, browser_name):
 def test_should_support_with_statement(browser_name):
     with get_browser(browser_name):
         pass
+
+
+@pytest.mark.parametrize('browser_name', supported_browsers)
+def test_browser_config(request, browser_name):
+    """Splinter's drivers get the Config object when it's passed through the Browser function."""
+    from splinter import Config
+
+    config = Config(user_agent="agent_smith")
+    browser = get_browser(browser_name, config=config)
+    request.addfinalizer(browser.quit)
+
+    assert browser.config.user_agent == 'agent_smith'

--- a/tests/test_webdriver_firefox.py
+++ b/tests/test_webdriver_firefox.py
@@ -9,6 +9,8 @@ import unittest
 
 import pytest
 
+from splinter.config import Config
+
 from .fake_webapp import EXAMPLE_APP
 from .base import WebDriverTests, get_browser
 
@@ -46,7 +48,8 @@ def test_firefox_create_instance_with_extension(request):
         'borderify-1.0-an+fx.xpi',
     )
 
-    browser = get_browser('firefox', extensions=[extension_path])
+    config = Config(extensions=[extension_path])
+    browser = get_browser('firefox', config=config)
     request.addfinalizer(browser.quit)
 
     browser.visit(EXAMPLE_APP)


### PR DESCRIPTION
Fixes #602

This PR adds a new object called Config. It's designed to act as a simple alternative to Selenium Options objects and replace custom arguments to the various drivers. It also allows Remote Webdriver to benefit from the same behaviour as the other Selenium drivers.

e.g.: Instead of:
```
Browser('chrome', headless=True, fullscreen=True)
```

It's now:

```
my_config = Config(headless=True, fullscreen=True)
Browser('chrome', config=my_config)
```

This reduces the number of explicit arguments sent to the browser and still allows custom arguments to be sent directly to the driver.