### PR TITLE
Remove Python 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - PY_VER: py37
-            python-version: 3.7
           - PY_VER: py38
             python-version: 3.8
           - PY_VER: py39
@@ -31,7 +29,7 @@ jobs:
           - PY_VER: py310
             python-version: "3.10"
           - PY_VER: py311
-            python-version: "3.11"
+            python-version: 3.11
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,16 +16,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - PY_VER: py37
-            python-version: 3.7
           - PY_VER: py38
             python-version: 3.8
           - PY_VER: py39
             python-version: 3.9
           - PY_VER: py310
-            python-version: '3.10'
+            python-version: "3.10"
           - PY_VER: py311
-            python-version: "3.11"
+            python-version: 3.11
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,23 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2012 splinter authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
 
 
 def read(filename: str) -> str:
     path = os.path.join(os.path.dirname(__file__), filename)
-    with open(path, 'r') as f:
+    with open(path, "r") as f:
         return f.read()
 
 
 def get_version_data() -> dict:
     data = {}
 
-    path = os.path.join(os.path.dirname(__file__), 'splinter', 'version.py')
+    path = os.path.join(os.path.dirname(__file__), "splinter", "version.py")
 
     with open(path) as fp:
         exec(fp.read(), data)
@@ -30,10 +30,10 @@ version_data = get_version_data()
 
 setup(
     name="splinter",
-    version=version_data['__version__'],
+    version=version_data["__version__"],
     url="https://github.com/cobrateam/splinter",
     description="browser abstraction for web acceptance testing",
-    long_description=read('README.rst'),
+    long_description=read("README.rst"),
     author="CobraTeam",
     author_email="andrewsmedina@gmail.com",
     license="BSD",
@@ -41,7 +41,10 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3",
     ]
-    + [("Programming Language :: Python :: %s" % x) for x in "3.7 3.8 3.9 3.10 3.11".split()],
+    + [
+        ("Programming Language :: Python :: %s" % x)
+        for x in "3.8 3.9 3.10 3.11".split()
+    ],
     project_urls={
         "Documentation": "https://splinter.readthedocs.io/",
         "Changelog": "https://github.com/cobrateam/splinter/tree/master/docs/news",
@@ -50,9 +53,7 @@ setup(
     },
     packages=find_packages(exclude=["docs", "tests", "samples"]),
     include_package_data=True,
-    install_requires=[
-        "urllib3 >=1.26.14,<3.0"
-    ],
+    install_requires=["urllib3 >=1.26.14,<3.0"],
     extras_require={
         "zope.testbrowser": ["zope.testbrowser>=6.0", "lxml>=4.2.4", "cssselect"],
         "django": ["Django>=2.0.6", "lxml>=4.2.4", "cssselect"],


### PR DESCRIPTION
Python 3.7 has reached end of life, let's remove it from CI and from setup.py.