### PR TITLE
moved desired_capabilities inside if statement to add compatibility …

### DIFF
--- a/splinter/driver/webdriver/remote.py
+++ b/splinter/driver/webdriver/remote.py
@@ -43,7 +43,7 @@ class WebDriver(BaseWebDriver):
             # Combine user's desired capabilities with default
             caps.update(kwargs["desired_capabilities"])
 
-        kwargs["desired_capabilities"] = caps
+            kwargs["desired_capabilities"] = caps
 
         kwargs["command_executor"] = command_executor
 


### PR DESCRIPTION
According to this commit here https://github.com/SeleniumHQ/selenium/commit/9f5801c82fb3be3d5850707c46c3f8176e3ccd8e#diff-89ba579445647535b74423c7bf4b8be79ef1ce33847a2768e623c3083a33545d

`desired_capabilities` has been removed from selenium 4.10.0 and up. This commits allows for old and new versions of selenium to work either using the newer `options` argument or the old `desired_capabilities`. This also prevents the error from selenium `TypeError: WebDriver.__init__() got an unexpected keyword argument 'desired_capabilities'`
It fixes issue [#1173](https://github.com/cobrateam/splinter/issues/1173)