### PR TITLE
Make User Agent None by default

### DIFF
--- a/splinter/config.py
+++ b/splinter/config.py
@@ -49,4 +49,4 @@ class Config:
     fullscreen: Optional[bool] = False
     headless: Optional[bool] = False
     incognito: Optional[bool] = False
-    user_agent: Optional[str] = ""
+    user_agent: Optional[str] = None


### PR DESCRIPTION
In Splinter 0.20.0 was introduced `splinter.config.Config` which has `user_agent = ''`
It leads to empty string of User Agent in a browser. As result any applicaiton which checks User-Agent think the browser is invalid.

I tried it with Standalone Cromium 117 in docker. 
`driver.execute_script("return navigator.userAgent")` will return `''` instead of `'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36'`