### PR TITLE
Remove deprecation warning

### DIFF
--- a/splinter/driver/webdriver/chrome.py
+++ b/splinter/driver/webdriver/chrome.py
@@ -28,20 +28,6 @@ class WebDriver(BaseWebDriver):
         config: Optional[Config] = None,
         **kwargs,
     ):
-        if "executable_path" in kwargs:
-            warnings.warn(
-                (
-                    "Webdriver's executable_path argument has been deprecated."
-                    "Please pass in a selenium Service object instead."
-                ),
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            if service is None:
-                service = Service(executable_path=kwargs["executable_path"])
-            else:
-                service.executable_path = kwargs["executable_path"]
-
         if True in [fullscreen, incognito, headless] or user_agent:
             warnings.warn(
                 (

--- a/splinter/driver/webdriver/edge.py
+++ b/splinter/driver/webdriver/edge.py
@@ -29,20 +29,6 @@ class WebDriver(BaseWebDriver):
         config: Optional[Config] = None,
         **kwargs,
     ):
-        if "executable_path" in kwargs:
-            warnings.warn(
-                (
-                    "Webdriver's executable_path argument has been deprecated."
-                    "Please pass in a selenium Service object instead."
-                ),
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            if service is None:
-                service = Service(executable_path=kwargs["executable_path"])
-            else:
-                service.executable_path = kwargs["executable_path"]
-
         if True in [fullscreen, incognito, headless] or user_agent:
             warnings.warn(
                 (

--- a/splinter/driver/webdriver/firefox.py
+++ b/splinter/driver/webdriver/firefox.py
@@ -32,20 +32,6 @@ class WebDriver(BaseWebDriver):
         config: Optional[Config] = None,
         **kwargs,
     ):
-        if "executable_path" in kwargs:
-            warnings.warn(
-                (
-                    "Webdriver's executable_path argument has been deprecated."
-                    "Please pass in a selenium Service object instead."
-                ),
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            if service is None:
-                service = Service(executable_path=kwargs["executable_path"])
-            else:
-                service.executable_path = kwargs["executable_path"]
-
         if True in [fullscreen, incognito, headless] or user_agent:
             warnings.warn(
                 (


### PR DESCRIPTION
Remove the deprecation warning and handler for the executable_path argument. It's been about a year and the documentation has already been updated.