### PR TITLE
Replace documentation theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,12 @@ import splinter
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
+    'sphinx_immaterial',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']
@@ -93,45 +98,52 @@ pygments_style = "vs"
 
 # -- Options for HTML output ---------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-# html_theme = 'nature'
-if not os.environ.get("READTHEDOCS", None):
-    import sphinx_rtd_theme
+html_theme = 'sphinx_immaterial'
+html_static_path = ['_static']
 
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
-# documentation.
 html_theme_options = {
-    "collapse_navigation": False,
+    "repo_url": "https://github.com/cobrateam/splinter",
+    "repo_name": "splinter",
+    "icon": {
+        "repo": "fontawesome/brands/git",
+        "edit": "material/file-edit-outline",
+    },
+    "font": False,
+    "features": [
+        "navigation.expand",
+        "navigation.sections",
+        "navigation.top",
+        "navigation.tracking",
+        "search.share",
+        "toc.follow",
+        "toc.sticky",
+        "content.tabs.link",
+        "announce.dismiss",
+    ],
+    "palette": [
+        {
+            "media": "(prefers-color-scheme: light)",
+            "scheme": "default",
+            "primary": "deep-purple",
+            "accent": "amber",
+            "toggle": {
+                "icon": "material/lightbulb-outline",
+                "name": "Switch to dark mode",
+            },
+        },
+        {
+            "media": "(prefers-color-scheme: dark)",
+            "scheme": "slate",
+            "primary": "deep-purple",
+            "accent": "amber",
+            "toggle": {
+                "icon": "material/lightbulb",
+                "name": "Switch to light mode",
+            },
+        },
+    ],
+
 }
-
-# Add any paths that contain custom themes here, relative to this directory.
-# html_theme_path = []
-
-# The name for this set of Sphinx documents.  If None, it defaults to
-# "<project> v<release> documentation".
-# html_title = None
-
-# A shorter title for the navigation bar.  Default is the same as html_title.
-# html_short_title = None
-
-# The name of an image file (relative to this directory) to place at the top
-# of the sidebar.
-# html_logo = None
-
-# The name of an image file (within the static path) to use as favicon of the
-# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
-# pixels large.
-# html_favicon = None
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -1,5 +1,6 @@
 Sphinx>=1.7.8
-sphinx-rtd-theme>=0.1.8
+sphinx-immaterial>=0.11.10
 cssselect>=1.0.3
 lxml==5.1.0
+selenium==4.17.2
 zope.testbrowser==6.0


### PR DESCRIPTION
Compared to the RTD theme, the immaterial theme has cleaner formatting and a dark mode for free. It's popular so we may as well buy in. This PR also fixes a break that happened at some point where the docs hosted on readthedocs did not use the correct theme.