### PR TITLE
Start using a generic retry function

### DIFF
--- a/splinter/retry.py
+++ b/splinter/retry.py
@@ -9,24 +9,35 @@ def _retry(
     fn_args: Optional[list] = None,
     fn_kwargs: Optional[dict] = None,
     timeout: int = 0,
-) -> bool:
-    """Retry a function that should return a truthy value until a timeout is hit.
+) -> Any:
+    """Retry a function until it returns a non-falsey result or timeout is hit.
+
+    If timeout is set to 0, the function will only be run once.
+
+    This will not wrap Exceptions, only falsey values.
 
     Arguments:
-        fn: Function to retry
-        timeout: Number of seconds to retry.
+        fn: A function to retry.
+        timeout: How long, in seconds, to retry the function.
 
     Returns:
-        bool - True if the function returns a truthy value before the timeout, else False.
-
+        The final return value of func.
     """
     fn_args = fn_args or []
     fn_kwargs = fn_kwargs or {}
 
-    end_time = time.time() + timeout
+    result = None
 
-    while time.time() < end_time:
+    # Zero second wait time means only check once
+    if timeout == 0:
         result = fn(*fn_args, **fn_kwargs)
-        if result:
-            return True
-    return False
+    else:
+        end_time = time.time() + timeout
+
+        while time.time() < end_time:
+            result = fn(*fn_args, **fn_kwargs)
+
+            if result:
+                break
+
+    return result


### PR DESCRIPTION
- Rewrite `_find` to only handle the Selenium actions.
- Rewrite `find_by` to use the generic `_retry` function.
- Rewrite the `_retry` function to return the result of the function instead of a bool.