### PR TITLE
Use ABC for CookieManagerAPI

### DIFF
--- a/splinter/abc/__init__.py
+++ b/splinter/abc/__init__.py
@@ -1,0 +1,3 @@
+from cookie_manager import CookieManagerAPI
+
+__all__ = ["CookieManagerAPI"]

--- a/splinter/abc/__init__.py
+++ b/splinter/abc/__init__.py
@@ -1,3 +1,3 @@
-from cookie_manager import CookieManagerAPI
+from .cookie_manager import CookieManagerAPI
 
 __all__ = ["CookieManagerAPI"]

--- a/splinter/abc/cookie_manager.py
+++ b/splinter/abc/cookie_manager.py
@@ -1,7 +1,8 @@
 # Copyright 2012 splinter authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-from abc import ABC, abstractmethod
+from abc import ABC
+from abc import abstractmethod
 
 
 class CookieManagerAPI(ABC):

--- a/splinter/abc/cookie_manager.py
+++ b/splinter/abc/cookie_manager.py
@@ -1,17 +1,21 @@
 # Copyright 2012 splinter authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
+from abc import ABC, abstractmethod
 
 
-class CookieManagerAPI:
-    """An API that specifies how a splinter driver deals with cookies.
+class CookieManagerAPI(ABC):
+    """Specification for how a Splinter driver deals with cookies.
 
-    You can add cookies using the :meth:`add <CookieManagerAPI.add>` method,
-    and remove one or all cookies using
-    the :meth:`delete <CookieManagerAPI.delete>` method.
+    Add cookies using the :meth:`add <CookieManagerAPI.add>` method,
+    and remove cookies using
+    the :meth:`delete <CookieManagerAPI.delete>` and
+    :meth:`delete <CookieManagerAPI.delete_all>`methods.
 
     A CookieManager acts like a ``dict``, so you can access the value of a
     cookie through the [] operator, passing the cookie identifier:
+
+    Examples:
 
         >>> cookie_manager.add({'name': 'Tony'})
         >>> assert cookie_manager['name'] == 'Tony'
@@ -20,6 +24,7 @@ class CookieManagerAPI:
     def __init__(self, driver) -> None:
         self.driver = driver
 
+    @abstractmethod
     def add(self, cookie, **kwargs) -> None:
         """Add a cookie.
 
@@ -35,6 +40,7 @@ class CookieManagerAPI:
         """
         raise NotImplementedError
 
+    @abstractmethod
     def delete(self, *cookies: str) -> None:
         """Delete one or more cookies.
 
@@ -51,10 +57,12 @@ class CookieManagerAPI:
         """
         raise NotImplementedError
 
+    @abstractmethod
     def delete_all(self) -> None:
         """Delete all cookies."""
         raise NotImplementedError
 
+    @abstractmethod
     def all(self, verbose: bool = False):  # NOQA: A003
         """Get all of the cookies.
 
@@ -74,8 +82,14 @@ class CookieManagerAPI:
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def __contains__(self, key) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
     def __getitem__(self, item):
         raise NotImplementedError
 
+    @abstractmethod
     def __eq__(self, other_object) -> bool:
         raise NotImplementedError

--- a/splinter/driver/__init__.py
+++ b/splinter/driver/__init__.py
@@ -8,7 +8,7 @@ from typing import Any
 from typing import Optional
 from typing import Type
 
-from splinter.cookie_manager import CookieManagerAPI
+from splinter.abc import CookieManagerAPI
 from splinter.element_list import ElementList
 
 

--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -6,7 +6,7 @@ from urllib import parse
 
 from .lxmldriver import LxmlDriver
 from splinter.config import Config
-from splinter.cookie_manager import CookieManagerAPI
+from splinter.abc import CookieManagerAPI
 from splinter.request_handler.status_code import StatusCode
 
 

--- a/splinter/driver/djangoclient.py
+++ b/splinter/driver/djangoclient.py
@@ -5,8 +5,8 @@ from typing import Optional
 from urllib import parse
 
 from .lxmldriver import LxmlDriver
-from splinter.config import Config
 from splinter.abc import CookieManagerAPI
+from splinter.config import Config
 from splinter.request_handler.status_code import StatusCode
 
 

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -8,8 +8,8 @@ from urllib.parse import urlparse
 from urllib.parse import urlunparse
 
 from .lxmldriver import LxmlDriver
-from splinter.config import Config
 from splinter.abc import CookieManagerAPI
+from splinter.config import Config
 from splinter.request_handler.status_code import StatusCode
 
 

--- a/splinter/driver/flaskclient.py
+++ b/splinter/driver/flaskclient.py
@@ -9,7 +9,7 @@ from urllib.parse import urlunparse
 
 from .lxmldriver import LxmlDriver
 from splinter.config import Config
-from splinter.cookie_manager import CookieManagerAPI
+from splinter.abc import CookieManagerAPI
 from splinter.request_handler.status_code import StatusCode
 
 

--- a/splinter/driver/webdriver/cookie_manager.py
+++ b/splinter/driver/webdriver/cookie_manager.py
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 from urllib.parse import urlparse
 
-from splinter.cookie_manager import CookieManagerAPI
+from splinter.abc import CookieManagerAPI
 
 
 class CookieManager(CookieManagerAPI):

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -12,8 +12,8 @@ from lxml.cssselect import CSSSelector
 from zope.testbrowser.browser import Browser
 from zope.testbrowser.browser import ListControl
 
-from splinter.config import Config
 from splinter.abc import CookieManagerAPI
+from splinter.config import Config
 from splinter.driver import DriverAPI
 from splinter.driver import ElementAPI
 from splinter.driver.element_present import ElementPresentMixIn

--- a/splinter/driver/zopetestbrowser.py
+++ b/splinter/driver/zopetestbrowser.py
@@ -13,7 +13,7 @@ from zope.testbrowser.browser import Browser
 from zope.testbrowser.browser import ListControl
 
 from splinter.config import Config
-from splinter.cookie_manager import CookieManagerAPI
+from splinter.abc import CookieManagerAPI
 from splinter.driver import DriverAPI
 from splinter.driver import ElementAPI
 from splinter.driver.element_present import ElementPresentMixIn


### PR DESCRIPTION
This PR:
  - Adds the `__contains__` method to the CookieManagerAPI interface
  - Uses the ABC module to enforce the Splinter API 

Using ABC as a base class has some advantages for creating interfaces. The abstractmethod decorator forces subclasses to implement the decorated methods. Eventually, I'd like to have DriverAPI and ElementAPI use ABC as a base class.